### PR TITLE
Improve GitHub Actions: CI, deploy pipeline and branch protection

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,76 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create .env
+        run: cp src/.env.testing infra/scheduler/.env
+
+      - name: Build and start containers
+        run: docker compose -f infra/scheduler/docker-compose.yml up -d
+
+      - name: Install Dependencies
+        run: docker compose -f infra/scheduler/docker-compose.yml exec -T world-scraper composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+
+      - name: Directory Permissions
+        run: docker compose -f infra/scheduler/docker-compose.yml exec -T world-scraper chmod -R 777 storage bootstrap/cache
+
+      - name: Create SqlLite database
+        run: docker compose -f infra/scheduler/docker-compose.yml exec -T world-scraper touch database/database.sqlite
+
+      - name: Generate App key
+        run: docker compose -f infra/scheduler/docker-compose.yml exec -T world-scraper php artisan key:generate
+
+      - name: Run Migrations
+        run: docker compose -f infra/scheduler/docker-compose.yml exec -T world-scraper php artisan migrate --force
+
+      - name: Run Seeders
+        run: docker compose -f infra/scheduler/docker-compose.yml exec -T world-scraper php artisan db:seed
+
+      - name: Run Tests with PHPUnit + Xdebug
+        run: docker compose -f infra/scheduler/docker-compose.yml exec -T world-scraper vendor/bin/phpunit --colors=never
+
+  deploy:
+    name: Deploy to Servers
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy to Front
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.DEPLOY_HOST_FRONT }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          fingerprint: ${{ secrets.DEPLOY_HOST_FRONT_FINGERPRINT }}
+          script: |
+            cd /var/www/tibia-hunteds-site
+            git fetch --all
+            git reset --hard ${{ github.sha }}
+            composer install --no-dev --optimize-autoloader --no-interaction --no-ansi
+            php artisan migrate --force
+
+      - name: Deploy to Crawler
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.DEPLOY_HOST_CRAWLER }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          fingerprint: ${{ secrets.DEPLOY_HOST_CRAWLER_FINGERPRINT }}
+          script: |
+            cd /var/www/tibia-hunteds-site
+            git fetch --all
+            git reset --hard ${{ github.sha }}
+            composer install --no-dev --optimize-autoloader --no-interaction --no-ansi
+            php artisan migrate --force
+            sudo systemctl restart world-scraper.service schedule-run.service

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,15 +1,16 @@
-name: Laravel
+name: CI
 
 on:
   pull_request:
-  push:
+    branches:
+      - main
 
 jobs:
   laravel-tests:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Create .env
         run: cp src/.env.testing infra/scheduler/.env

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /.phpunit.cache
 /.vscode
 /.zed
+.claude/settings.local.json
+src/.claude/settings.local.json


### PR DESCRIPTION
## Summary

- Atualiza o workflow de CI para rodar apenas em Pull Requests targeting `main` (remove trigger de push direto)
- Adiciona workflow de deploy que executa os testes e, somente se passar, faz deploy via SSH nas máquinas **Front** e **Crawler** (restart de serviços apenas no Crawler)
- Adiciona script para configurar proteção da branch main via `gh` CLI

## Secrets necessários no GitHub

| Secret | Descrição |
|---|---|
| `DEPLOY_HOST_FRONT` | IP/hostname da máquina Front |
| `DEPLOY_HOST_CRAWLER` | IP/hostname da máquina Crawler |
| `DEPLOY_USER` | Usuário SSH |
| `DEPLOY_SSH_KEY` | Chave SSH privada |

## Test plan

- [ ] Abrir uma PR e verificar que o workflow `CI` dispara
- [ ] Fazer novo commit na PR e verificar que o CI roda novamente
- [ ] Fazer merge na main e verificar que o workflow `Deploy` dispara
- [ ] Verificar que o deploy não ocorre se os testes falharem
- [ ] Rodar `protect-main-branch.sh` e verificar que push direto na main é bloqueado

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configured main branch protection with enforced status checks and admin enforcement.
  * Added an automated deployment workflow for production releases.
  * Updated CI workflow triggers and action versions.

* **Tests**
  * Added automated continuous integration testing that runs on main and during pull requests.

* **Style**
  * Updated ignore patterns to exclude local tooling configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->