### PR TITLE
Fix failing tests by adding SettingFactory and HasFactory trait

### DIFF
--- a/src/app/Models/Setting.php
+++ b/src/app/Models/Setting.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -9,5 +10,5 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $value
  */
 class Setting extends Model {
-
+    use HasFactory;
 }

--- a/src/database/factories/SettingFactory.php
+++ b/src/database/factories/SettingFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class SettingFactory  extends Factory {
+
+    public function definition(): array {
+        return [
+            'name' => $this->faker->name(),
+            'value' => $this->faker->name(),
+        ];
+    }
+
+}

--- a/src/tests/Feature/App/Scrapers/GuildPageTest.php
+++ b/src/tests/Feature/App/Scrapers/GuildPageTest.php
@@ -5,6 +5,7 @@ use App\Character\GuildEnum;
 use App\Character\GuildPageCharacter;
 use App\Character\VocationEnum;
 use App\Models\Character;
+use App\Models\Setting;
 use App\Scrapers\GuildPage;
 use Carbon\Carbon;
 use Tests\Support\GuildPageHtml;
@@ -13,6 +14,7 @@ use Tests\TestCase;
 class GuildPageTest extends TestCase {
 
     public function testScrap_WhenPlayerIsOfflineInDatabase_AndIsOnlineOnHtml_ShouldMarkAsOnline(): void {
+        Setting::factory()->create();
         Carbon::setTestNow($expectedOnlineAt = Carbon::now());
         $guildPageCharacter = new GuildPageCharacter();
         $guildPageCharacter->rank = 'Leader';

--- a/src/tests/Feature/App/Scrapers/GuildPageTest.php
+++ b/src/tests/Feature/App/Scrapers/GuildPageTest.php
@@ -7,6 +7,7 @@ use App\Character\VocationEnum;
 use App\Models\Character;
 use App\Models\Setting;
 use App\Scrapers\GuildPage;
+use App\Setting\SettingConfig;
 use Carbon\Carbon;
 use Tests\Support\GuildPageHtml;
 use Tests\TestCase;
@@ -14,7 +15,7 @@ use Tests\TestCase;
 class GuildPageTest extends TestCase {
 
     public function testScrap_WhenPlayerIsOfflineInDatabase_AndIsOnlineOnHtml_ShouldMarkAsOnline(): void {
-        Setting::factory()->create();
+        Setting::factory()->create(['name' => SettingConfig::GUILD_NAME->value]);
         Carbon::setTestNow($expectedOnlineAt = Carbon::now());
         $guildPageCharacter = new GuildPageCharacter();
         $guildPageCharacter->rank = 'Leader';

--- a/src/tests/Feature/ExampleTest.php
+++ b/src/tests/Feature/ExampleTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 // use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\Setting;
 use Tests\TestCase;
 
 class ExampleTest extends TestCase
@@ -12,6 +13,7 @@ class ExampleTest extends TestCase
      */
     public function test_the_application_returns_a_successful_response(): void
     {
+        Setting::factory()->create();
         $response = $this->get('/');
 
         $response->assertStatus(200);

--- a/src/tests/Feature/ExampleTest.php
+++ b/src/tests/Feature/ExampleTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 // use Illuminate\Foundation\Testing\RefreshDatabase;
 use App\Models\Setting;
+use App\Setting\SettingConfig;
 use Tests\TestCase;
 
 class ExampleTest extends TestCase
@@ -13,7 +14,7 @@ class ExampleTest extends TestCase
      */
     public function test_the_application_returns_a_successful_response(): void
     {
-        Setting::factory()->create();
+        Setting::factory()->create(['name' => SettingConfig::GUILD_NAME->value]);
         $response = $this->get('/');
 
         $response->assertStatus(200);

--- a/src/tests/TestCase.php
+++ b/src/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use App\Models\Setting;
 use App\Scrapers\GuildPage;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Illuminate\Support\Facades\DB;

--- a/src/tests/TestCase.php
+++ b/src/tests/TestCase.php
@@ -24,5 +24,6 @@ abstract class TestCase extends BaseTestCase {
         DB::table('character_online_times')->truncate();
         DB::table('characters')->truncate();
         DB::table('execution_crawlers')->truncate();
+        DB::table('settings')->truncate();
     }
 }


### PR DESCRIPTION
## Summary
- Cria `SettingFactory` para suportar a criação de dados de teste para o model `Setting`
- Adiciona o trait `HasFactory` ao model `Setting`
- Usa `Setting::factory()->create()` nos testes que dependem de um registro de `Setting` existente

## Test plan
- [ ] Executar `php artisan test` e verificar que todos os testes passam

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tests now use a dedicated factory to generate setting data and seed required configuration during test runs.

* **Chores**
  * Added a settings factory and updated test setup to ensure settings are created and cleaned up between runs (database cleanup).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->