### PR TITLE
Fix crawler deploy: add cd to src dir and split systemctl restart

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,9 +71,11 @@ jobs:
             cd /var/www/tibia-hunteds-site
             git fetch --all
             git reset --hard ${{ github.sha }}
+            cd /var/www/tibia-hunteds-site/src
             composer install --no-dev --optimize-autoloader --no-interaction --no-ansi
             php artisan migrate --force
             php artisan config:cache
             php artisan route:cache
             php artisan view:cache
-            sudo systemctl restart world-scraper.service schedule-run.service
+            sudo systemctl restart world-scraper.service
+            sudo systemctl restart schedule-run.service


### PR DESCRIPTION
## Summary
- Adiciona `cd /var/www/tibia-hunteds-site/src` antes dos comandos `composer` e `artisan` no deploy do Crawler, corrigindo falha por diretório incorreto
- Separa o `systemctl restart` em dois comandos para melhor isolamento de falhas nos logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)