### PR TITLE
Fix deploy: use origin/main instead of github.sha

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,8 +54,8 @@ jobs:
           key: ${{ secrets.DEPLOY_SSH_KEY_FRONT }}
           script: |
             cd /var/www/tibia-hunteds-site
-            git fetch --all
-            git reset --hard ${{ github.sha }}
+            git fetch origin main
+            git reset --hard origin/main
             docker exec app_web-app-1 composer install --no-dev --optimize-autoloader --no-interaction --no-ansi
             docker exec app_web-app-1 php artisan config:cache
             docker exec app_web-app-1 php artisan route:cache
@@ -69,8 +69,8 @@ jobs:
           key: ${{ secrets.DEPLOY_SSH_KEY_CRAWLER }}
           script: |
             cd /var/www/tibia-hunteds-site
-            git fetch --all
-            git reset --hard ${{ github.sha }}
+            git fetch origin main
+            git reset --hard origin/main
             cd /var/www/tibia-hunteds-site/src
             composer install --no-dev --optimize-autoloader --no-interaction --no-ansi
             php artisan migrate --force


### PR DESCRIPTION
## Summary
- Substitui `git reset --hard ${{ github.sha }}` por `git reset --hard origin/main` em ambos os deploys (Front e Crawler)
- `github.sha` era instável: o commit pode não existir localmente no servidor caso o repositório esteja desatualizado, fazendo o deploy aplicar um estado incorreto (ex: conteúdo de uma PR antiga)
- `origin/main` garante que o servidor sempre aplica o estado completo e atualizado do branch main após o merge

## Test plan
- [ ] Fazer merge de uma PR e verificar que o deploy aplica o estado completo de `main`
- [ ] Confirmar que não há resíduos de PRs anteriores nos servidores após o deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)