### PR TITLE
Skip tr rows with invalid td count in GuildPage scraper

### DIFF
--- a/src/app/Scrapers/GuildPage.php
+++ b/src/app/Scrapers/GuildPage.php
@@ -61,6 +61,10 @@ class GuildPage {
                 continue;
             }
 
+            if ($guildPageTrIterator->getElementByTagName('td')->count() !== 6) {
+                continue;
+            }
+
             try {
                 $guildPageCharacter = $guildPageTrIterator->buildGuildPageCharacter($this->guildName);
                 $databaseCharacter = $guildPageTrIterator->findDatabaseCharacter($guildCharacters);

--- a/src/tests/Feature/App/Scrapers/GuildPageTest.php
+++ b/src/tests/Feature/App/Scrapers/GuildPageTest.php
@@ -72,6 +72,14 @@ class GuildPageTest extends TestCase {
         $this->assertNull($databaseCharacter->online_at);
     }
 
+    public function testScrap_WhenTrHasLessThan6Tds_ShouldSkipRowWithoutError(): void {
+        $html = GuildPageHtml::listOfCharactersWithInvalidTdCount();
+
+        GuildPage::getInstance($html, GuildEnum::OUTLAW->value)->scrap();
+
+        $this->assertDatabaseCount('characters', 0);
+    }
+
     public function testScrap_WhenPlayerIsOnlineInDatabase_AndDidntExistsInHtml_ShouldMarkAsOfflineAndDeleteFromDatabase() {
         Carbon::setTestNow($expectedOnlineAt = Carbon::now());
         $guildPageCharacter = new GuildPageCharacter();

--- a/src/tests/Support/GuildPageHtml.php
+++ b/src/tests/Support/GuildPageHtml.php
@@ -55,6 +55,21 @@ HTML;
 HTML;
     }
 
+    public static function listOfCharactersWithInvalidTdCount(): string {
+        $invalidRow = '<tr bgcolor="#F1E0C6"><td>Leader</td><td>Only Four</td><td>Knight</td><td>100</td></tr>';
+        $html = <<<HTML
+        <div id="guilds">
+            <div class="TableContainer">
+                <table class="TableContent">
+                    <tr class="LabelH"><td>Rank</td><td>Name</td><td>Vocation</td><td>Level</td><td>Joining Date</td><td>Status</td></tr>
+                    $invalidRow
+                </table>
+            </div>
+        </div>
+HTML;
+        return $html;
+    }
+
     private static function buildOnlineTd(bool $isOnline): string {
         return $isOnline ?
             '<td class="onlinestatus"><span class="green"><b>online</b></span></td></tr>':


### PR DESCRIPTION
## Summary
- Adiciona validação que ignora `tr` com quantidade diferente de 6 `td`s antes de processar o personagem
- Previne erros ao tentar acessar índices inexistentes em linhas malformadas do HTML da guild page
- Adiciona teste cobrindo o comportamento de skip

## Test plan
- [ ] `testScrap_WhenTrHasLessThan6Tds_ShouldSkipRowWithoutError` deve passar sem erros e sem criar registros no banco

🤖 Generated with [Claude Code](https://claude.com/claude-code)