### PR TITLE
feat: exibe personagens deslogados riscados por 15 minutos

### DIFF
--- a/src/app/Character/GuildPageCharacter.php
+++ b/src/app/Character/GuildPageCharacter.php
@@ -16,6 +16,7 @@ class GuildPageCharacter {
     public bool $is_online;
     public string $guild_name;
     public ?Carbon $online_at = null;
+    public ?Carbon $offline_at = null;
 
     public function getJoiningDateFormated(): string {
         return $this->joining_date->format('M d Y');
@@ -53,6 +54,7 @@ class GuildPageCharacter {
         if ($this->online_at !== null) {
             $array['online_at'] = $this->online_at;
         }
+        $array['offline_at'] = $this->offline_at;
         return $array;
     }
 }

--- a/src/app/Character/Repository/DatabaseCharacterRepository.php
+++ b/src/app/Character/Repository/DatabaseCharacterRepository.php
@@ -10,7 +10,10 @@ class DatabaseCharacterRepository implements CharacterRepository {
 
     public function getOnlinePlayer(?string $guildName = null): Collection {
         $query = Character::query()
-        ->where('is_online', true);
+            ->where(function ($q) {
+                $q->where('is_online', true)
+                  ->orWhere('offline_at', '>=', now()->subMinutes(15));
+            });
 
         if (!is_null($guildName)) {
             $query->where('guild_name', $guildName);
@@ -34,7 +37,7 @@ class DatabaseCharacterRepository implements CharacterRepository {
         Character::upsert(
             $characters->toArray(),
             ['name'],
-            ['name', 'vocation', 'level', 'joining_date', 'is_online', 'guild_name', 'online_at'],
+            ['name', 'vocation', 'level', 'joining_date', 'is_online', 'guild_name', 'online_at', 'offline_at'],
         );
     }
 

--- a/src/app/Http/Controllers/HomeController.php
+++ b/src/app/Http/Controllers/HomeController.php
@@ -26,7 +26,13 @@ class HomeController extends Controller {
 
     public function getOnlineCharacters(Request $request): JsonResponse {
         $guildName = $request->get('guild_name');
-        return response()->json(['onlineCharacters' => $this->characterService->retrieveOnlinePlayers($guildName)]);
+        $characters = $this->characterService->retrieveOnlinePlayers($guildName);
+
+        if (!$request->user()) {
+            $characters = $characters->filter(fn($c) => $c->is_online)->values();
+        }
+
+        return response()->json(['onlineCharacters' => $characters]);
     }
 
     public function setCharacterType(string $characterName, string $type): JsonResponse {

--- a/src/app/Models/Character.php
+++ b/src/app/Models/Character.php
@@ -26,6 +26,7 @@ class Character extends Model {
 
     protected $casts = [
         'online_at' => 'datetime',
+        'offline_at' => 'datetime',
         'position_time' => 'datetime',
         'is_attacker_character' => 'boolean',
         'is_online' => 'boolean',
@@ -40,6 +41,7 @@ class Character extends Model {
             'type' => $this->type,
             'is_online' => $this->is_online,
             'online_at' => $this->online_at ? $this->online_at->format('Y-m-d H:i:s') : null,
+            'offline_at' => $this->offline_at ? $this->offline_at->format('Y-m-d H:i:s') : null,
             'position_time' => $this->position_time ? $this->position_time->format('Y-m-d H:i:s') : null,
             'position' => $this->position,
             'is_attacker_character' => $this->is_attacker_character,

--- a/src/app/Scrapers/GuildPage.php
+++ b/src/app/Scrapers/GuildPage.php
@@ -76,6 +76,7 @@ class GuildPage {
                         }
                     }
                     $guildPageCharacter->online_at = $databaseCharacter->online_at;
+                    $guildPageCharacter->offline_at = null;
                     if ($databaseCharacter->is_online === false) {
                         $guildPageCharacter->online_at = now();
                     }
@@ -104,6 +105,7 @@ class GuildPage {
             ->update([
                 'is_online' => false,
                 'online_at' => null,
+                'offline_at' => now(),
                 'position' => null,
                 'position_time' => null,
             ]);
@@ -112,6 +114,7 @@ class GuildPage {
             ->update([
                 'is_online' => false,
                 'online_at' => null,
+                'offline_at' => now(),
                 'position' => null,
                 'position_time' => null,
             ]);

--- a/src/database/migrations/2026_03_10_000000_add_offline_at_into_characters_table.php
+++ b/src/database/migrations/2026_03_10_000000_add_offline_at_into_characters_table.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void {
+        Schema::table('characters', function (Blueprint $table) {
+            $table->timestamp('offline_at')->nullable()->after('online_at');
+        });
+    }
+
+    public function down(): void {
+        Schema::table('characters', function (Blueprint $table) {
+            $table->dropColumn('offline_at');
+        });
+    }
+};

--- a/src/public/css/observe.css
+++ b/src/public/css/observe.css
@@ -152,3 +152,9 @@ th {
 .btn-windows:active {
     background: rgba(255,255,255,0.12);
 }
+
+.offline-character td {
+    text-decoration: line-through;
+    opacity: 0.45;
+    color: #aaa;
+}

--- a/src/public/js/observe.js
+++ b/src/public/js/observe.js
@@ -99,7 +99,7 @@ function addRow(tableId, index, character, isOffline = false) {
 
     if (isOffline) {
         row.className = 'offline-character';
-        const offlineAt = serverDate(character.offline_at + " UTC");
+        const offlineAt = new Date(character.offline_at);
         const offlineId = `offline-at-${tableId}-${character.name.replace(/\s+/g, '-')}`;
 
         row.innerHTML = `

--- a/src/public/js/observe.js
+++ b/src/public/js/observe.js
@@ -99,7 +99,7 @@ function addRow(tableId, index, character, isOffline = false) {
 
     if (isOffline) {
         row.className = 'offline-character';
-        const offlineAt = new Date(character.offline_at);
+        const offlineAt = serverDate(character.offline_at + " UTC");
         const offlineId = `offline-at-${tableId}-${character.name.replace(/\s+/g, '-')}`;
 
         row.innerHTML = `

--- a/src/public/js/observe.js
+++ b/src/public/js/observe.js
@@ -92,46 +92,64 @@ function renderVocationImg(vocation) {
     }
 }
 
-function addRow(tableId, index, character) {
+function addRow(tableId, index, character, isOffline = false) {
     const tbody = document.querySelector(`#${tableId} tbody`);
     const row = document.createElement('tr');
-    row.className = 'vocation-tr';
-    const createdAtDate = serverDate(character.online_at+ " UTC");
-    const positionAtDate = character.position_time !== null ? serverDate(character.position_time+ " UTC") : null;
-    createdAtMap.set(`created-at-${tableId}-${index}`, createdAtDate);
-    positionTimeMap.set(`position-time-${tableId}-${index}`, positionAtDate);
-
     const imgVocation = renderVocationImg(character.vocation);
-    row.innerHTML = `
-        <td>#${index + 1}</td>
-        <td>${character.name}</td>
-        <td>${character.level}</td>
-        <td>${imgVocation}<span class="vocation-text">${character.vocation}</span></td>
-        <td id="created-at-${tableId}-${index}" class="normal">00:00:00</td>
-        <td id="position-time-${tableId}-${index}" class="normal"></td>
-        <td id="position" class="normal">${character.position ?? ''}</td>
-      `;
 
-    row.style.cursor = "pointer";
-    row.title = `Clique para copiar: exiva "${character.name}"`;
-    if (character.is_attacker_character) {
-        row.className = 'attack-character';
+    if (isOffline) {
+        row.className = 'offline-character';
+        const offlineAt = serverDate(character.offline_at + " UTC");
+        const offlineId = `offline-at-${tableId}-${character.name.replace(/\s+/g, '-')}`;
+
+        row.innerHTML = `
+            <td>#-</td>
+            <td>${character.name}</td>
+            <td>${character.level}</td>
+            <td>${imgVocation}<span class="vocation-text">${character.vocation}</span></td>
+            <td id="${offlineId}" class="normal">00:00:00</td>
+            <td class="normal"></td>
+            <td class="normal"></td>
+        `;
+        createdAtMap.set(offlineId, offlineAt);
+    } else {
+        row.className = 'vocation-tr';
+        const createdAtDate = serverDate(character.online_at+ " UTC");
+        const positionAtDate = character.position_time !== null ? serverDate(character.position_time+ " UTC") : null;
+        createdAtMap.set(`created-at-${tableId}-${index}`, createdAtDate);
+        positionTimeMap.set(`position-time-${tableId}-${index}`, positionAtDate);
+
+        row.innerHTML = `
+            <td>#${index + 1}</td>
+            <td>${character.name}</td>
+            <td>${character.level}</td>
+            <td>${imgVocation}<span class="vocation-text">${character.vocation}</span></td>
+            <td id="created-at-${tableId}-${index}" class="normal">00:00:00</td>
+            <td id="position-time-${tableId}-${index}" class="normal"></td>
+            <td id="position" class="normal">${character.position ?? ''}</td>
+        `;
+
+        if (character.is_attacker_character) {
+            row.className = 'attack-character';
+        }
+
+        row.style.cursor = "pointer";
+        row.title = `Clique para copiar: exiva "${character.name}"`;
+        row.addEventListener("click", () => {
+            const text = `exiva "${character.name}"`;
+            copyToClipboard(text);
+            showCopyToast(`Copiado: ${text}`);
+        });
+        row.addEventListener("contextmenu", (event) => {
+            if (!contextMenu) return;
+            event.preventDefault();
+            contextMenuTarget = character;
+            contextMenu.style.top = `${event.pageY}px`;
+            contextMenu.style.left = `${event.pageX}px`;
+            contextMenu.style.display = "block";
+            document.getElementById('input-position').focus();
+        });
     }
-
-    row.addEventListener("click", () => {
-        const text = `exiva "${character.name}"`;
-        copyToClipboard(text);
-        showCopyToast(`Copiado: ${text}`);
-    });
-    row.addEventListener("contextmenu", (event) => {
-        if (!contextMenu) return;
-        event.preventDefault();
-        contextMenuTarget = character;
-        contextMenu.style.top = `${event.pageY}px`;
-        contextMenu.style.left = `${event.pageX}px`;
-        contextMenu.style.display = "block";
-        document.getElementById('input-position').focus();
-    });
 
     tbody.appendChild(row);
 }
@@ -261,15 +279,22 @@ async function fetchOnlineCharacters() {
         createdAtMap.clear();
         positionTimeMap.clear();
 
-        const sortedCharacters = data.onlineCharacters.sort((a, b) => {
-            const timeA = serverDate() - serverDate(a.online_at+ " UTC");
-            const timeB = serverDate() - serverDate(b.online_at+ " UTC");
-            return timeA - timeB; // ordem crescente: menor tempo online primeiro
-        });
+        const onlineCharacters = data.onlineCharacters
+            .filter(c => c.is_online)
+            .sort((a, b) => {
+                const timeA = serverDate() - serverDate(a.online_at + " UTC");
+                const timeB = serverDate() - serverDate(b.online_at + " UTC");
+                return timeA - timeB;
+            });
+        const offlineCharacters = data.onlineCharacters
+            .filter(c => !c.is_online)
+            .sort((a, b) => {
+                return serverDate(b.offline_at + " UTC") - serverDate(a.offline_at + " UTC");
+            });
 
         let mainIndex = 0, bombaIndex = 0, bombaoIndex = 0, makerIndex = 0;
 
-        sortedCharacters.forEach(character => {
+        onlineCharacters.forEach(character => {
             if (character.type === 'main') {
                 addRow('mainCharTable', mainIndex++, character);
             } else if (character.type === 'bomba') {
@@ -281,12 +306,20 @@ async function fetchOnlineCharacters() {
             }
         });
 
+        offlineCharacters.forEach(character => {
+            const tableId = character.type === 'main' ? 'mainCharTable'
+                : character.type === 'bomba' ? 'bombasTable'
+                : character.type === 'bombao' ? 'bombaoTable'
+                : 'makersTable';
+            addRow(tableId, -1, character, true);
+        });
+
         document.getElementById('lastUpdate').textContent =
             `Atualizado em: ${serverDate().toLocaleTimeString()}`;
 
         updateCreatedAtTimers();
         updatePositionTimeTimers();
-        document.title = sortedCharacters.length + ' Characters Online';
+        document.title = onlineCharacters.length + ' Characters Online';
     } catch (error) {
         console.error('Erro ao buscar personagens:', error);
     } finally {

--- a/src/resources/views/observer.blade.php
+++ b/src/resources/views/observer.blade.php
@@ -4,7 +4,7 @@
 @extends('layouts.default')
 
 @push('css')
-    <link rel="stylesheet" href="{{ asset('css/observe.css?v=202601272129') }}">
+    <link rel="stylesheet" href="{{ asset('css/observe.css?v=202603100000') }}">
 @endpush
 
 @section('content')
@@ -164,6 +164,6 @@
     <script>
         window.SERVER_TIME = "{{ now()->format('Y-m-d H:i:s') }}";
     </script>
-    <script src="{{ asset('js/observe.js?v=202601272129') }}"></script>
+    <script src="{{ asset('js/observe.js?v=202603100000') }}"></script>
 
 @endsection

--- a/src/tests/Feature/App/Character/Repository/DatabaseCharacterRepositoryTest.php
+++ b/src/tests/Feature/App/Character/Repository/DatabaseCharacterRepositoryTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Feature\App\Character\Repository;
+
+use App\Character\Repository\DatabaseCharacterRepository;
+use App\Models\Character;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class DatabaseCharacterRepositoryTest extends TestCase {
+
+    private DatabaseCharacterRepository $repository;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Storage::fake('local');
+        $this->repository = new DatabaseCharacterRepository();
+    }
+
+    public function testGetOnlinePlayer_WhenCharacterIsOnline_ShouldReturnIt(): void {
+        $character = Character::factory()->create(['is_online' => true, 'offline_at' => null]);
+
+        $result = $this->repository->getOnlinePlayer();
+
+        $this->assertTrue($result->contains('id', $character->id));
+    }
+
+    public function testGetOnlinePlayer_WhenCharacterIsOfflineWithin15Minutes_ShouldReturnIt(): void {
+        $character = Character::factory()->create([
+            'is_online' => false,
+            'offline_at' => now()->subMinutes(10),
+        ]);
+
+        $result = $this->repository->getOnlinePlayer();
+
+        $this->assertTrue($result->contains('id', $character->id));
+    }
+
+    public function testGetOnlinePlayer_WhenCharacterIsOfflineMoreThan15Minutes_ShouldNotReturnIt(): void {
+        $character = Character::factory()->create([
+            'is_online' => false,
+            'offline_at' => now()->subMinutes(16),
+        ]);
+
+        $result = $this->repository->getOnlinePlayer();
+
+        $this->assertFalse($result->contains('id', $character->id));
+    }
+
+    public function testGetOnlinePlayer_WhenGuildNameProvided_ShouldFilterByGuild(): void {
+        $characterA = Character::factory()->create(['is_online' => true, 'guild_name' => 'GuildA']);
+        $characterB = Character::factory()->create(['is_online' => true, 'guild_name' => 'GuildB']);
+
+        $result = $this->repository->getOnlinePlayer('GuildA');
+
+        $this->assertTrue($result->contains('id', $characterA->id));
+        $this->assertFalse($result->contains('id', $characterB->id));
+    }
+
+    public function testGetOnlinePlayer_ShouldSaveResultToStorage(): void {
+        Character::factory()->create(['is_online' => true]);
+
+        $this->repository->getOnlinePlayer();
+
+        $files = Storage::disk('local')->files('/cache/online-characters');
+        $this->assertCount(1, $files);
+    }
+
+    public function testFirstCharacterByName_WhenCharacterExists_ShouldReturnIt(): void {
+        $character = Character::factory()->create(['name' => 'Fabio Selokoo']);
+
+        $result = $this->repository->firstCharacterByName('Fabio Selokoo');
+
+        $this->assertNotNull($result);
+        $this->assertEquals($character->id, $result->id);
+    }
+
+    public function testFirstCharacterByName_WhenCharacterDoesNotExist_ShouldReturnNull(): void {
+        $result = $this->repository->firstCharacterByName('Unknown Character');
+
+        $this->assertNull($result);
+    }
+
+    public function testUpdateCharacterTypeUsingName_ShouldUpdateType(): void {
+        $character = Character::factory()->create(['name' => 'Fabio Selokoo', 'type' => 'enemy']);
+
+        $this->repository->updateCharacterTypeUsingName('Fabio Selokoo', 'ally');
+
+        $this->assertEquals('ally', $character->fresh()->type);
+    }
+
+    public function testUpsertCharacters_WhenCharacterDoesNotExist_ShouldCreateIt(): void {
+        $data = collect([[
+            'name' => 'New Character',
+            'vocation' => 'Knight',
+            'level' => 100,
+            'joining_date' => '2024-01-01',
+            'is_online' => true,
+            'guild_name' => 'TestGuild',
+            'online_at' => null,
+            'offline_at' => null,
+        ]]);
+
+        $this->repository->upsertCharacters($data);
+
+        $this->assertDatabaseHas('characters', ['name' => 'New Character', 'level' => 100]);
+    }
+
+    public function testUpsertCharacters_WhenCharacterExists_ShouldUpdateLevel(): void {
+        Character::factory()->create(['name' => 'Existing Character', 'level' => 100, 'guild_name' => 'TestGuild']);
+
+        $data = collect([[
+            'name' => 'Existing Character',
+            'vocation' => 'Knight',
+            'level' => 200,
+            'joining_date' => '2024-01-01',
+            'is_online' => true,
+            'guild_name' => 'TestGuild',
+            'online_at' => null,
+            'offline_at' => null,
+        ]]);
+
+        $this->repository->upsertCharacters($data);
+
+        $this->assertDatabaseHas('characters', ['name' => 'Existing Character', 'level' => 200]);
+    }
+
+    public function testGetAllCharactersByGuildName_ShouldReturnOnlyGuildCharacters(): void {
+        Character::factory()->create(['guild_name' => 'TargetGuild']);
+        Character::factory()->create(['guild_name' => 'OtherGuild']);
+
+        $result = $this->repository->getAllCharactersByGuildName('TargetGuild');
+
+        $this->assertCount(1, $result);
+        $this->assertEquals('TargetGuild', $result->first()->guild_name);
+    }
+
+    public function testUpdateCharacterIsAttacker_ShouldUpdateFlag(): void {
+        $character = Character::factory()->create(['name' => 'Attacker', 'is_attacker_character' => false]);
+
+        $this->repository->updateCharacterIsAttacker('Attacker', true);
+
+        $this->assertTrue($character->fresh()->is_attacker_character);
+    }
+}

--- a/src/tests/Feature/App/Http/Controllers/HomeControllerTest.php
+++ b/src/tests/Feature/App/Http/Controllers/HomeControllerTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Tests\Feature\App\Http\Controllers;
+
+use App\Models\Character;
+use App\Models\Setting;
+use App\Models\User;
+use App\Setting\SettingConfig;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class HomeControllerTest extends TestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        Storage::fake('local');
+    }
+
+    public function testIndex_ShouldReturnObserverView(): void {
+        Setting::factory()->create(['name' => SettingConfig::GUILD_NAME->value, 'value' => 'TestGuild']);
+
+        $response = $this->get(route('home'));
+
+        $response->assertStatus(200);
+        $response->assertViewIs('observer');
+    }
+
+    public function testGetOnlineCharacters_WhenUnauthenticated_ShouldReturnOnlyOnlineCharacters(): void {
+        Character::factory()->create(['is_online' => true, 'offline_at' => null]);
+        Character::factory()->create(['is_online' => false, 'offline_at' => now()->subMinutes(5)]);
+
+        $response = $this->getJson(route('get-online-characters'));
+
+        $response->assertStatus(200);
+        $onlineCharacters = $response->json('onlineCharacters');
+        $this->assertCount(1, $onlineCharacters);
+        $this->assertTrue($onlineCharacters[0]['is_online']);
+    }
+
+    public function testGetOnlineCharacters_WhenAuthenticated_ShouldReturnOnlineAndRecentlyOfflineCharacters(): void {
+        $user = User::factory()->create();
+        Character::factory()->create(['is_online' => true, 'offline_at' => null]);
+        Character::factory()->create(['is_online' => false, 'offline_at' => now()->subMinutes(5)]);
+
+        $response = $this->actingAs($user)->getJson(route('get-online-characters'));
+
+        $response->assertStatus(200);
+        $this->assertCount(2, $response->json('onlineCharacters'));
+    }
+
+    public function testSetCharacterType_WhenUnauthenticated_ShouldRedirectToLogin(): void {
+        $response = $this->post(route('update.character.type', ['characterName' => 'Test', 'type' => 'enemy']));
+
+        $response->assertRedirect(route('login.index'));
+    }
+
+    public function testSetCharacterType_WhenAuthenticated_ShouldUpdateCharacterType(): void {
+        $user = User::factory()->create();
+        $character = Character::factory()->create(['name' => 'TestChar', 'type' => 'enemy']);
+
+        $response = $this->actingAs($user)->post(
+            route('update.character.type', ['characterName' => 'TestChar', 'type' => 'ally'])
+        );
+
+        $response->assertStatus(200);
+        $this->assertEquals('ally', $character->fresh()->type);
+    }
+
+    public function testSetCharacterAsAttacker_WhenUnauthenticated_ShouldRedirectToLogin(): void {
+        $response = $this->post(
+            route('update.character.attacker', ['characterName' => 'Test', 'isAttacker' => 'true'])
+        );
+
+        $response->assertRedirect(route('login.index'));
+    }
+
+    public function testSetCharacterAsAttacker_WhenAuthenticated_ShouldMarkCharacterAsAttacker(): void {
+        $user = User::factory()->create();
+        $character = Character::factory()->create(['name' => 'TestChar', 'is_attacker_character' => false]);
+
+        $this->actingAs($user)->post(
+            route('update.character.attacker', ['characterName' => 'TestChar', 'isAttacker' => 'true'])
+        );
+
+        $this->assertTrue($character->fresh()->is_attacker_character);
+    }
+
+    public function testSetCharacterAsAttacker_WhenPassingFalse_ShouldUnmarkCharacterAsAttacker(): void {
+        $user = User::factory()->create();
+        $character = Character::factory()->create(['name' => 'TestChar', 'is_attacker_character' => true]);
+
+        $this->actingAs($user)->post(
+            route('update.character.attacker', ['characterName' => 'TestChar', 'isAttacker' => 'false'])
+        );
+
+        $this->assertFalse($character->fresh()->is_attacker_character);
+    }
+
+    public function testSettings_WhenUnauthenticated_ShouldRedirectToLogin(): void {
+        $response = $this->get(route('settings'));
+
+        $response->assertRedirect(route('login.index'));
+    }
+
+    public function testSettings_WhenAuthenticated_ShouldReturnSettingsView(): void {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('settings'));
+
+        $response->assertStatus(200);
+        $response->assertViewIs('settings');
+    }
+
+    public function testSaveSettings_WhenAuthenticated_ShouldPersistGuildName(): void {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->post(route('settings.save'), ['guild_name' => 'NewGuild']);
+
+        $this->assertDatabaseHas('settings', [
+            'name' => SettingConfig::GUILD_NAME->value,
+            'value' => 'NewGuild',
+        ]);
+    }
+
+    public function testRefil_ShouldReturnRefilView(): void {
+        $response = $this->get(route('refil'));
+
+        $response->assertStatus(200);
+        $response->assertViewIs('refil');
+    }
+}

--- a/src/tests/Unit/App/Character/GuildPageCharacterTest.php
+++ b/src/tests/Unit/App/Character/GuildPageCharacterTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Unit\App\Character;
+
+use App\Character\GuildPageCharacter;
+use App\Character\VocationEnum;
+use Carbon\Carbon;
+use PHPUnit\Framework\TestCase;
+
+class GuildPageCharacterTest extends TestCase {
+
+    public function testRemoveSpace_WhenStringHasNbsp_ShouldReplaceWithSpace(): void {
+        $result = GuildPageCharacter::removeSpace("Hello\xC2\xA0World");
+
+        $this->assertEquals('Hello World', $result);
+    }
+
+    public function testRemoveSpace_WhenStringHasMultipleSpaces_ShouldNormalizeToOne(): void {
+        $result = GuildPageCharacter::removeSpace('Hello   World');
+
+        $this->assertEquals('Hello World', $result);
+    }
+
+    public function testRemoveSpace_WhenStringHasLeadingAndTrailingSpaces_ShouldTrim(): void {
+        $result = GuildPageCharacter::removeSpace('  Hello World  ');
+
+        $this->assertEquals('Hello World', $result);
+    }
+
+    public function testRemoveSpace_WhenStringHasHtmlNbspEntity_ShouldReplaceWithSpace(): void {
+        $result = GuildPageCharacter::removeSpace('Hello&nbsp;World');
+
+        $this->assertEquals('Hello World', $result);
+    }
+
+    public function testGetStatus_WhenStatusHasGreenSpanAndBoldTags_ShouldStripThem(): void {
+        $html = '<span class="green"><b>online</b></span>';
+
+        $result = GuildPageCharacter::getStatus($html);
+
+        $this->assertEquals('online', $result);
+    }
+
+    public function testGetStatus_WhenStatusHasRedSpanTag_ShouldStripIt(): void {
+        $html = '<span class="red">Offline</span>';
+
+        $result = GuildPageCharacter::getStatus($html);
+
+        $this->assertEquals('offline', $result);
+    }
+
+    public function testGetStatus_ShouldReturnLowercase(): void {
+        $result = GuildPageCharacter::getStatus('ONLINE');
+
+        $this->assertEquals('online', $result);
+    }
+
+    public function testToArray_WhenOnlineAtIsNull_ShouldNotIncludeOnlineAt(): void {
+        $character = $this->buildCharacter();
+        $character->online_at = null;
+
+        $array = $character->toArray();
+
+        $this->assertArrayNotHasKey('online_at', $array);
+    }
+
+    public function testToArray_WhenOnlineAtIsSet_ShouldIncludeOnlineAt(): void {
+        $character = $this->buildCharacter();
+        $character->online_at = Carbon::now();
+
+        $array = $character->toArray();
+
+        $this->assertArrayHasKey('online_at', $array);
+    }
+
+    public function testToArray_ShouldAlwaysIncludeOfflineAt(): void {
+        $character = $this->buildCharacter();
+        $character->offline_at = Carbon::now();
+
+        $array = $character->toArray();
+
+        $this->assertArrayHasKey('offline_at', $array);
+    }
+
+    public function testToArray_ShouldIncludeCoreFields(): void {
+        $character = $this->buildCharacter();
+
+        $array = $character->toArray();
+
+        $this->assertArrayHasKey('name', $array);
+        $this->assertArrayHasKey('vocation', $array);
+        $this->assertArrayHasKey('level', $array);
+        $this->assertArrayHasKey('joining_date', $array);
+        $this->assertArrayHasKey('is_online', $array);
+        $this->assertArrayHasKey('guild_name', $array);
+    }
+
+    public function testGetJoiningDateFormated_ShouldReturnDateInExpectedFormat(): void {
+        $character = new GuildPageCharacter();
+        $character->joining_date = Carbon::create(2024, 3, 10);
+
+        $result = $character->getJoiningDateFormated();
+
+        $this->assertEquals('Mar 10 2024', $result);
+    }
+
+    private function buildCharacter(): GuildPageCharacter {
+        $character = new GuildPageCharacter();
+        $character->rank = 'Leader';
+        $character->name = 'Test Character';
+        $character->vocation = VocationEnum::EK;
+        $character->level = 100;
+        $character->joining_date = Carbon::now();
+        $character->is_online = true;
+        $character->guild_name = 'TestGuild';
+        return $character;
+    }
+}

--- a/src/tests/Unit/App/Models/CharacterTest.php
+++ b/src/tests/Unit/App/Models/CharacterTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Unit\App\Models;
+
+use App\Models\Character;
+use Carbon\Carbon;
+use Tests\TestCase;
+
+class CharacterTest extends TestCase {
+
+    public function testToArray_ShouldIncludeAllExpectedFields(): void {
+        $character = new Character();
+        $character->name = 'Test';
+        $character->vocation = 'Knight';
+        $character->level = 100;
+        $character->joining_date = '2024-01-01';
+        $character->type = 'enemy';
+        $character->is_online = true;
+        $character->is_attacker_character = false;
+
+        $array = $character->toArray();
+
+        $this->assertArrayHasKey('name', $array);
+        $this->assertArrayHasKey('vocation', $array);
+        $this->assertArrayHasKey('level', $array);
+        $this->assertArrayHasKey('is_online', $array);
+        $this->assertArrayHasKey('is_attacker_character', $array);
+        $this->assertArrayHasKey('online_at', $array);
+        $this->assertArrayHasKey('offline_at', $array);
+        $this->assertArrayHasKey('position_time', $array);
+        $this->assertArrayHasKey('position', $array);
+    }
+
+    public function testToArray_WhenDatesAreNull_ShouldSerializeAsNull(): void {
+        $character = new Character();
+        $character->online_at = null;
+        $character->offline_at = null;
+        $character->position_time = null;
+
+        $array = $character->toArray();
+
+        $this->assertNull($array['online_at']);
+        $this->assertNull($array['offline_at']);
+        $this->assertNull($array['position_time']);
+    }
+
+    public function testToArray_WhenDatesAreSet_ShouldFormatAsYmdHis(): void {
+        $character = new Character();
+        $character->online_at = Carbon::create(2024, 3, 10, 12, 0, 0);
+        $character->offline_at = Carbon::create(2024, 3, 10, 13, 0, 0);
+        $character->position_time = Carbon::create(2024, 3, 10, 14, 0, 0);
+
+        $array = $character->toArray();
+
+        $this->assertEquals('2024-03-10 12:00:00', $array['online_at']);
+        $this->assertEquals('2024-03-10 13:00:00', $array['offline_at']);
+        $this->assertEquals('2024-03-10 14:00:00', $array['position_time']);
+    }
+
+    public function testIsOnlineCast_WhenRetrievedFromDatabase_ShouldBeBoolean(): void {
+        $character = Character::factory()->create(['is_online' => true]);
+
+        $this->assertIsBool($character->fresh()->is_online);
+        $this->assertTrue($character->fresh()->is_online);
+    }
+
+    public function testIsAttackerCharacterCast_WhenRetrievedFromDatabase_ShouldBeBoolean(): void {
+        $character = Character::factory()->create(['is_attacker_character' => false]);
+
+        $this->assertIsBool($character->fresh()->is_attacker_character);
+        $this->assertFalse($character->fresh()->is_attacker_character);
+    }
+
+    public function testOnlineAtCast_WhenRetrievedFromDatabase_ShouldBeCarbonInstance(): void {
+        $now = Carbon::now()->startOfSecond();
+        $character = Character::factory()->create(['online_at' => $now]);
+
+        $this->assertInstanceOf(Carbon::class, $character->fresh()->online_at);
+        $this->assertEquals($now->toDateTimeString(), $character->fresh()->online_at->toDateTimeString());
+    }
+}


### PR DESCRIPTION
## Summary
- Adiciona coluna `offline_at` na tabela characters para registrar o momento do deslogamento
- Exibe personagens deslogados riscados na lista por 15 minutos após ficarem offline
- Corrige `NaN:NaN:NaN` no timer: `offline_at` não estava sendo serializado no `toArray()` do model `Character`
- Personagens offline só são enviados na resposta da API para usuários autenticados
- Adiciona testes para `DatabaseCharacterRepository`, `GuildPageCharacter`, `HomeController` e `Character`

## Test plan
- [ ] Verificar que personagens offline exibem o timer corretamente (ex: `00:01:30`) e não `NaN:NaN:NaN`
- [ ] Verificar que usuários não logados não veem personagens offline na tabela
- [ ] Verificar que usuários logados continuam vendo personagens offline normalmente
- [ ] Rodar `php artisan test` e verificar todos os testes passando

🤖 Generated with [Claude Code](https://claude.com/claude-code)