### PR TITLE
test: testes para DatabaseCharacterRepository e Character

### DIFF
--- a/src/tests/Feature/App/Character/Repository/DatabaseCharacterRepositoryTest.php
+++ b/src/tests/Feature/App/Character/Repository/DatabaseCharacterRepositoryTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Feature\App\Character\Repository;
+
+use App\Character\Repository\DatabaseCharacterRepository;
+use App\Models\Character;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class DatabaseCharacterRepositoryTest extends TestCase {
+
+    private DatabaseCharacterRepository $repository;
+
+    protected function setUp(): void {
+        parent::setUp();
+        Storage::fake('local');
+        $this->repository = new DatabaseCharacterRepository();
+    }
+
+    public function testGetOnlinePlayer_WhenCharacterIsOnline_ShouldReturnIt(): void {
+        $character = Character::factory()->create(['is_online' => true, 'offline_at' => null]);
+
+        $result = $this->repository->getOnlinePlayer();
+
+        $this->assertTrue($result->contains('id', $character->id));
+    }
+
+    public function testGetOnlinePlayer_WhenCharacterIsOfflineWithin15Minutes_ShouldReturnIt(): void {
+        $character = Character::factory()->create([
+            'is_online' => false,
+            'offline_at' => now()->subMinutes(10),
+        ]);
+
+        $result = $this->repository->getOnlinePlayer();
+
+        $this->assertTrue($result->contains('id', $character->id));
+    }
+
+    public function testGetOnlinePlayer_WhenCharacterIsOfflineMoreThan15Minutes_ShouldNotReturnIt(): void {
+        $character = Character::factory()->create([
+            'is_online' => false,
+            'offline_at' => now()->subMinutes(16),
+        ]);
+
+        $result = $this->repository->getOnlinePlayer();
+
+        $this->assertFalse($result->contains('id', $character->id));
+    }
+
+    public function testGetOnlinePlayer_WhenGuildNameProvided_ShouldFilterByGuild(): void {
+        $characterA = Character::factory()->create(['is_online' => true, 'guild_name' => 'GuildA']);
+        $characterB = Character::factory()->create(['is_online' => true, 'guild_name' => 'GuildB']);
+
+        $result = $this->repository->getOnlinePlayer('GuildA');
+
+        $this->assertTrue($result->contains('id', $characterA->id));
+        $this->assertFalse($result->contains('id', $characterB->id));
+    }
+
+    public function testGetOnlinePlayer_ShouldSaveResultToStorage(): void {
+        Character::factory()->create(['is_online' => true]);
+
+        $this->repository->getOnlinePlayer();
+
+        $files = Storage::disk('local')->files('/cache/online-characters');
+        $this->assertCount(1, $files);
+    }
+
+    public function testFirstCharacterByName_WhenCharacterExists_ShouldReturnIt(): void {
+        $character = Character::factory()->create(['name' => 'Fabio Selokoo']);
+
+        $result = $this->repository->firstCharacterByName('Fabio Selokoo');
+
+        $this->assertNotNull($result);
+        $this->assertEquals($character->id, $result->id);
+    }
+
+    public function testFirstCharacterByName_WhenCharacterDoesNotExist_ShouldReturnNull(): void {
+        $result = $this->repository->firstCharacterByName('Unknown Character');
+
+        $this->assertNull($result);
+    }
+
+    public function testUpdateCharacterTypeUsingName_ShouldUpdateType(): void {
+        $character = Character::factory()->create(['name' => 'Fabio Selokoo', 'type' => 'enemy']);
+
+        $this->repository->updateCharacterTypeUsingName('Fabio Selokoo', 'ally');
+
+        $this->assertEquals('ally', $character->fresh()->type);
+    }
+
+    public function testUpsertCharacters_WhenCharacterDoesNotExist_ShouldCreateIt(): void {
+        $data = collect([[
+            'name' => 'New Character',
+            'vocation' => 'Knight',
+            'level' => 100,
+            'joining_date' => '2024-01-01',
+            'is_online' => true,
+            'guild_name' => 'TestGuild',
+            'online_at' => null,
+            'offline_at' => null,
+        ]]);
+
+        $this->repository->upsertCharacters($data);
+
+        $this->assertDatabaseHas('characters', ['name' => 'New Character', 'level' => 100]);
+    }
+
+    public function testUpsertCharacters_WhenCharacterExists_ShouldUpdateLevel(): void {
+        Character::factory()->create(['name' => 'Existing Character', 'level' => 100, 'guild_name' => 'TestGuild']);
+
+        $data = collect([[
+            'name' => 'Existing Character',
+            'vocation' => 'Knight',
+            'level' => 200,
+            'joining_date' => '2024-01-01',
+            'is_online' => true,
+            'guild_name' => 'TestGuild',
+            'online_at' => null,
+            'offline_at' => null,
+        ]]);
+
+        $this->repository->upsertCharacters($data);
+
+        $this->assertDatabaseHas('characters', ['name' => 'Existing Character', 'level' => 200]);
+    }
+
+    public function testGetAllCharactersByGuildName_ShouldReturnOnlyGuildCharacters(): void {
+        Character::factory()->create(['guild_name' => 'TargetGuild']);
+        Character::factory()->create(['guild_name' => 'OtherGuild']);
+
+        $result = $this->repository->getAllCharactersByGuildName('TargetGuild');
+
+        $this->assertCount(1, $result);
+        $this->assertEquals('TargetGuild', $result->first()->guild_name);
+    }
+
+    public function testUpdateCharacterIsAttacker_ShouldUpdateFlag(): void {
+        $character = Character::factory()->create(['name' => 'Attacker', 'is_attacker_character' => false]);
+
+        $this->repository->updateCharacterIsAttacker('Attacker', true);
+
+        $this->assertTrue($character->fresh()->is_attacker_character);
+    }
+}

--- a/src/tests/Unit/App/Models/CharacterTest.php
+++ b/src/tests/Unit/App/Models/CharacterTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Unit\App\Models;
+
+use App\Models\Character;
+use Carbon\Carbon;
+use Tests\TestCase;
+
+class CharacterTest extends TestCase {
+
+    public function testToArray_ShouldIncludeAllExpectedFields(): void {
+        $character = new Character();
+        $character->name = 'Test';
+        $character->vocation = 'Knight';
+        $character->level = 100;
+        $character->joining_date = '2024-01-01';
+        $character->type = 'enemy';
+        $character->is_online = true;
+        $character->is_attacker_character = false;
+
+        $array = $character->toArray();
+
+        $this->assertArrayHasKey('name', $array);
+        $this->assertArrayHasKey('vocation', $array);
+        $this->assertArrayHasKey('level', $array);
+        $this->assertArrayHasKey('is_online', $array);
+        $this->assertArrayHasKey('is_attacker_character', $array);
+        $this->assertArrayHasKey('online_at', $array);
+        $this->assertArrayHasKey('offline_at', $array);
+        $this->assertArrayHasKey('position_time', $array);
+        $this->assertArrayHasKey('position', $array);
+    }
+
+    public function testToArray_WhenDatesAreNull_ShouldSerializeAsNull(): void {
+        $character = new Character();
+        $character->online_at = null;
+        $character->offline_at = null;
+        $character->position_time = null;
+
+        $array = $character->toArray();
+
+        $this->assertNull($array['online_at']);
+        $this->assertNull($array['offline_at']);
+        $this->assertNull($array['position_time']);
+    }
+
+    public function testToArray_WhenDatesAreSet_ShouldFormatAsYmdHis(): void {
+        $character = new Character();
+        $character->online_at = Carbon::create(2024, 3, 10, 12, 0, 0);
+        $character->offline_at = Carbon::create(2024, 3, 10, 13, 0, 0);
+        $character->position_time = Carbon::create(2024, 3, 10, 14, 0, 0);
+
+        $array = $character->toArray();
+
+        $this->assertEquals('2024-03-10 12:00:00', $array['online_at']);
+        $this->assertEquals('2024-03-10 13:00:00', $array['offline_at']);
+        $this->assertEquals('2024-03-10 14:00:00', $array['position_time']);
+    }
+
+    public function testIsOnlineCast_WhenRetrievedFromDatabase_ShouldBeBoolean(): void {
+        $character = Character::factory()->create(['is_online' => true]);
+
+        $this->assertIsBool($character->fresh()->is_online);
+        $this->assertTrue($character->fresh()->is_online);
+    }
+
+    public function testIsAttackerCharacterCast_WhenRetrievedFromDatabase_ShouldBeBoolean(): void {
+        $character = Character::factory()->create(['is_attacker_character' => false]);
+
+        $this->assertIsBool($character->fresh()->is_attacker_character);
+        $this->assertFalse($character->fresh()->is_attacker_character);
+    }
+
+    public function testOnlineAtCast_WhenRetrievedFromDatabase_ShouldBeCarbonInstance(): void {
+        $now = Carbon::now()->startOfSecond();
+        $character = Character::factory()->create(['online_at' => $now]);
+
+        $this->assertInstanceOf(Carbon::class, $character->fresh()->online_at);
+        $this->assertEquals($now->toDateTimeString(), $character->fresh()->online_at->toDateTimeString());
+    }
+}


### PR DESCRIPTION
## Summary
- Adiciona `DatabaseCharacterRepositoryTest` com 12 testes cobrindo todos os métodos do repositório (getOnlinePlayer com lógica de 15min, upsert, update, filtro por guild)
- Adiciona `CharacterTest` com 6 testes cobrindo serialização toArray, datas nulas e casts do Eloquent

## Test plan
- [ ] Rodar `php artisan test --filter="DatabaseCharacterRepositoryTest|CharacterTest"` e verificar 18 testes passando

🤖 Generated with [Claude Code](https://claude.com/claude-code)