### PR TITLE
test: testes para GuildPageCharacter e HomeController

### DIFF
--- a/src/tests/Feature/App/Http/Controllers/HomeControllerTest.php
+++ b/src/tests/Feature/App/Http/Controllers/HomeControllerTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Tests\Feature\App\Http\Controllers;
+
+use App\Models\Character;
+use App\Models\Setting;
+use App\Models\User;
+use App\Setting\SettingConfig;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class HomeControllerTest extends TestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        Storage::fake('local');
+    }
+
+    public function testIndex_ShouldReturnObserverView(): void {
+        Setting::factory()->create(['name' => SettingConfig::GUILD_NAME->value, 'value' => 'TestGuild']);
+
+        $response = $this->get(route('home'));
+
+        $response->assertStatus(200);
+        $response->assertViewIs('observer');
+    }
+
+    public function testGetOnlineCharacters_WhenUnauthenticated_ShouldReturnOnlyOnlineCharacters(): void {
+        Character::factory()->create(['is_online' => true, 'offline_at' => null]);
+        Character::factory()->create(['is_online' => false, 'offline_at' => now()->subMinutes(5)]);
+
+        $response = $this->getJson(route('get-online-characters'));
+
+        $response->assertStatus(200);
+        $onlineCharacters = $response->json('onlineCharacters');
+        $this->assertCount(1, $onlineCharacters);
+        $this->assertTrue($onlineCharacters[0]['is_online']);
+    }
+
+    public function testGetOnlineCharacters_WhenAuthenticated_ShouldReturnOnlineAndRecentlyOfflineCharacters(): void {
+        $user = User::factory()->create();
+        Character::factory()->create(['is_online' => true, 'offline_at' => null]);
+        Character::factory()->create(['is_online' => false, 'offline_at' => now()->subMinutes(5)]);
+
+        $response = $this->actingAs($user)->getJson(route('get-online-characters'));
+
+        $response->assertStatus(200);
+        $this->assertCount(2, $response->json('onlineCharacters'));
+    }
+
+    public function testSetCharacterType_WhenUnauthenticated_ShouldRedirectToLogin(): void {
+        $response = $this->post(route('update.character.type', ['characterName' => 'Test', 'type' => 'enemy']));
+
+        $response->assertRedirect(route('login.index'));
+    }
+
+    public function testSetCharacterType_WhenAuthenticated_ShouldUpdateCharacterType(): void {
+        $user = User::factory()->create();
+        $character = Character::factory()->create(['name' => 'TestChar', 'type' => 'enemy']);
+
+        $response = $this->actingAs($user)->post(
+            route('update.character.type', ['characterName' => 'TestChar', 'type' => 'ally'])
+        );
+
+        $response->assertStatus(200);
+        $this->assertEquals('ally', $character->fresh()->type);
+    }
+
+    public function testSetCharacterAsAttacker_WhenUnauthenticated_ShouldRedirectToLogin(): void {
+        $response = $this->post(
+            route('update.character.attacker', ['characterName' => 'Test', 'isAttacker' => 'true'])
+        );
+
+        $response->assertRedirect(route('login.index'));
+    }
+
+    public function testSetCharacterAsAttacker_WhenAuthenticated_ShouldMarkCharacterAsAttacker(): void {
+        $user = User::factory()->create();
+        $character = Character::factory()->create(['name' => 'TestChar', 'is_attacker_character' => false]);
+
+        $this->actingAs($user)->post(
+            route('update.character.attacker', ['characterName' => 'TestChar', 'isAttacker' => 'true'])
+        );
+
+        $this->assertTrue($character->fresh()->is_attacker_character);
+    }
+
+    public function testSetCharacterAsAttacker_WhenPassingFalse_ShouldUnmarkCharacterAsAttacker(): void {
+        $user = User::factory()->create();
+        $character = Character::factory()->create(['name' => 'TestChar', 'is_attacker_character' => true]);
+
+        $this->actingAs($user)->post(
+            route('update.character.attacker', ['characterName' => 'TestChar', 'isAttacker' => 'false'])
+        );
+
+        $this->assertFalse($character->fresh()->is_attacker_character);
+    }
+
+    public function testSettings_WhenUnauthenticated_ShouldRedirectToLogin(): void {
+        $response = $this->get(route('settings'));
+
+        $response->assertRedirect(route('login.index'));
+    }
+
+    public function testSettings_WhenAuthenticated_ShouldReturnSettingsView(): void {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('settings'));
+
+        $response->assertStatus(200);
+        $response->assertViewIs('settings');
+    }
+
+    public function testSaveSettings_WhenAuthenticated_ShouldPersistGuildName(): void {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->post(route('settings.save'), ['guild_name' => 'NewGuild']);
+
+        $this->assertDatabaseHas('settings', [
+            'name' => SettingConfig::GUILD_NAME->value,
+            'value' => 'NewGuild',
+        ]);
+    }
+
+    public function testRefil_ShouldReturnRefilView(): void {
+        $response = $this->get(route('refil'));
+
+        $response->assertStatus(200);
+        $response->assertViewIs('refil');
+    }
+}

--- a/src/tests/Unit/App/Character/GuildPageCharacterTest.php
+++ b/src/tests/Unit/App/Character/GuildPageCharacterTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Unit\App\Character;
+
+use App\Character\GuildPageCharacter;
+use App\Character\VocationEnum;
+use Carbon\Carbon;
+use PHPUnit\Framework\TestCase;
+
+class GuildPageCharacterTest extends TestCase {
+
+    public function testRemoveSpace_WhenStringHasNbsp_ShouldReplaceWithSpace(): void {
+        $result = GuildPageCharacter::removeSpace("Hello\xC2\xA0World");
+
+        $this->assertEquals('Hello World', $result);
+    }
+
+    public function testRemoveSpace_WhenStringHasMultipleSpaces_ShouldNormalizeToOne(): void {
+        $result = GuildPageCharacter::removeSpace('Hello   World');
+
+        $this->assertEquals('Hello World', $result);
+    }
+
+    public function testRemoveSpace_WhenStringHasLeadingAndTrailingSpaces_ShouldTrim(): void {
+        $result = GuildPageCharacter::removeSpace('  Hello World  ');
+
+        $this->assertEquals('Hello World', $result);
+    }
+
+    public function testRemoveSpace_WhenStringHasHtmlNbspEntity_ShouldReplaceWithSpace(): void {
+        $result = GuildPageCharacter::removeSpace('Hello&nbsp;World');
+
+        $this->assertEquals('Hello World', $result);
+    }
+
+    public function testGetStatus_WhenStatusHasGreenSpanAndBoldTags_ShouldStripThem(): void {
+        $html = '<span class="green"><b>online</b></span>';
+
+        $result = GuildPageCharacter::getStatus($html);
+
+        $this->assertEquals('online', $result);
+    }
+
+    public function testGetStatus_WhenStatusHasRedSpanTag_ShouldStripIt(): void {
+        $html = '<span class="red">Offline</span>';
+
+        $result = GuildPageCharacter::getStatus($html);
+
+        $this->assertEquals('offline', $result);
+    }
+
+    public function testGetStatus_ShouldReturnLowercase(): void {
+        $result = GuildPageCharacter::getStatus('ONLINE');
+
+        $this->assertEquals('online', $result);
+    }
+
+    public function testToArray_WhenOnlineAtIsNull_ShouldNotIncludeOnlineAt(): void {
+        $character = $this->buildCharacter();
+        $character->online_at = null;
+
+        $array = $character->toArray();
+
+        $this->assertArrayNotHasKey('online_at', $array);
+    }
+
+    public function testToArray_WhenOnlineAtIsSet_ShouldIncludeOnlineAt(): void {
+        $character = $this->buildCharacter();
+        $character->online_at = Carbon::now();
+
+        $array = $character->toArray();
+
+        $this->assertArrayHasKey('online_at', $array);
+    }
+
+    public function testToArray_ShouldAlwaysIncludeOfflineAt(): void {
+        $character = $this->buildCharacter();
+        $character->offline_at = Carbon::now();
+
+        $array = $character->toArray();
+
+        $this->assertArrayHasKey('offline_at', $array);
+    }
+
+    public function testToArray_ShouldIncludeCoreFields(): void {
+        $character = $this->buildCharacter();
+
+        $array = $character->toArray();
+
+        $this->assertArrayHasKey('name', $array);
+        $this->assertArrayHasKey('vocation', $array);
+        $this->assertArrayHasKey('level', $array);
+        $this->assertArrayHasKey('joining_date', $array);
+        $this->assertArrayHasKey('is_online', $array);
+        $this->assertArrayHasKey('guild_name', $array);
+    }
+
+    public function testGetJoiningDateFormated_ShouldReturnDateInExpectedFormat(): void {
+        $character = new GuildPageCharacter();
+        $character->joining_date = Carbon::create(2024, 3, 10);
+
+        $result = $character->getJoiningDateFormated();
+
+        $this->assertEquals('Mar 10 2024', $result);
+    }
+
+    private function buildCharacter(): GuildPageCharacter {
+        $character = new GuildPageCharacter();
+        $character->rank = 'Leader';
+        $character->name = 'Test Character';
+        $character->vocation = VocationEnum::EK;
+        $character->level = 100;
+        $character->joining_date = Carbon::now();
+        $character->is_online = true;
+        $character->guild_name = 'TestGuild';
+        return $character;
+    }
+}


### PR DESCRIPTION
## Summary
- Adiciona `GuildPageCharacterTest` com 12 testes cobrindo removeSpace (NBSP, espaços múltiplos), getStatus (strip de HTML, lowercase) e toArray
- Adiciona `HomeControllerTest` com 12 testes cobrindo todas as rotas: autenticação, filtro de offline para não autenticados, atualização de tipo/attacker/settings

## Test plan
- [ ] Rodar `php artisan test --filter="GuildPageCharacterTest|HomeControllerTest"` e verificar 24 testes passando

🤖 Generated with [Claude Code](https://claude.com/claude-code)