### PR TITLE
feat: gerenciamento de usuários - backend

### DIFF
--- a/src/app/Http/Controllers/UserController.php
+++ b/src/app/Http/Controllers/UserController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\View\View;
+
+class UserController extends Controller
+{
+    public function index(): View
+    {
+        $users = User::orderBy('name')->get();
+        return view('users', compact('users'));
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'name'     => 'required|string|max:255',
+            'email'    => 'required|email|unique:users,email',
+            'password' => 'required|string|min:8|confirmed',
+        ]);
+
+        User::create([
+            'name'     => $request->name,
+            'email'    => $request->email,
+            'password' => Hash::make($request->password),
+        ]);
+
+        return redirect()->route('users.index')->with('success', 'Usuário criado com sucesso!');
+    }
+
+    public function destroy(User $user): RedirectResponse
+    {
+        $user->delete();
+        return redirect()->route('users.index')->with('success', 'Usuário removido com sucesso!');
+    }
+}

--- a/src/app/Http/Middleware/SuperAdmin.php
+++ b/src/app/Http/Middleware/SuperAdmin.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SuperAdmin
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (!$request->user() || !$request->user()->super_admin) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/src/bootstrap/app.php
+++ b/src/bootstrap/app.php
@@ -12,6 +12,7 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->append(\App\Http\Middleware\CorsMiddleware::class);
+        $middleware->alias(['super_admin' => \App\Http\Middleware\SuperAdmin::class]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/src/resources/views/layouts/default.blade.php
+++ b/src/resources/views/layouts/default.blade.php
@@ -8,5 +8,6 @@
 </head>
 <body>
     @yield('content')
+    @stack('js')
 </body>
 </html>

--- a/src/resources/views/observer.blade.php
+++ b/src/resources/views/observer.blade.php
@@ -13,6 +13,7 @@
     <div>
         @if(Auth::hasUser() && Auth::user()->super_admin)
             <a href="{{ route('settings') }}" class="btn-windows" target="_blank">Configurações</a>
+            <a href="{{ route('users.index') }}" class="btn-windows" target="_blank">Usuários</a>
         @endif
         <input readonly disabled name="guild_name" id="guild-name" value="{{ ucfirst($guildName->value) }}">
         <select id="soundSelect" onchange="playSelectedSoundNTimes(1, this.value)">

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\LoginController;
+use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/login', [LoginController::class, 'index'])->name('login.index');
@@ -18,4 +19,10 @@ Route::middleware(['auth'])->group(function () {
     Route::post('/set/{characterName}/as/attacker/{isAttacker}', [HomeController::class, 'setCharacterAsAttacker'])->name('update.character.attacker');
     Route::post('/position/{characterName}', [HomeController::class, 'updateCharacterPosition'])->name('update.character.position');
     Route::get('/online-graphics-gant', [HomeController::class, 'getCharactersOnlineGantGraphics'])->name('online-graphics-gant');
+});
+
+Route::middleware(['auth', 'super_admin'])->group(function () {
+    Route::get('/users', [UserController::class, 'index'])->name('users.index');
+    Route::post('/users', [UserController::class, 'store'])->name('users.store');
+    Route::delete('/users/{user}', [UserController::class, 'destroy'])->name('users.destroy');
 });

--- a/src/tests/Feature/App/Http/Controllers/UserControllerTest.php
+++ b/src/tests/Feature/App/Http/Controllers/UserControllerTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Tests\Feature\App\Http\Controllers;
+
+use App\Models\User;
+use Tests\TestCase;
+
+class UserControllerTest extends TestCase
+{
+    // index
+
+    public function testIndex_WhenUnauthenticated_ShouldRedirectToLogin(): void
+    {
+        $response = $this->get(route('users.index'));
+
+        $response->assertRedirect(route('login.index'));
+    }
+
+    public function testIndex_WhenAuthenticatedAsNonSuperAdmin_ShouldReturn403(): void
+    {
+        $user = User::factory()->create(['super_admin' => false]);
+
+        $response = $this->actingAs($user)->get(route('users.index'));
+
+        $response->assertStatus(403);
+    }
+
+    // store
+
+    public function testStore_WhenUnauthenticated_ShouldRedirectToLogin(): void
+    {
+        $response = $this->post(route('users.store'), [
+            'name' => 'Test', 'email' => 'test@test.com',
+            'password' => 'password123', 'password_confirmation' => 'password123',
+        ]);
+
+        $response->assertRedirect(route('login.index'));
+    }
+
+    public function testStore_WhenAuthenticatedAsNonSuperAdmin_ShouldReturn403(): void
+    {
+        $user = User::factory()->create(['super_admin' => false]);
+
+        $response = $this->actingAs($user)->post(route('users.store'), [
+            'name' => 'Test', 'email' => 'test@test.com',
+            'password' => 'password123', 'password_confirmation' => 'password123',
+        ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function testStore_WhenValidData_ShouldCreateUser(): void
+    {
+        $admin = User::factory()->create(['super_admin' => true]);
+
+        $this->actingAs($admin)->post(route('users.store'), [
+            'name'                  => 'New User',
+            'email'                 => 'newuser@test.com',
+            'password'              => 'password123',
+            'password_confirmation' => 'password123',
+        ]);
+
+        $this->assertDatabaseHas('users', ['email' => 'newuser@test.com', 'name' => 'New User']);
+    }
+
+    public function testStore_WhenValidData_ShouldRedirectWithSuccess(): void
+    {
+        $admin = User::factory()->create(['super_admin' => true]);
+
+        $response = $this->actingAs($admin)->post(route('users.store'), [
+            'name'                  => 'New User',
+            'email'                 => 'newuser@test.com',
+            'password'              => 'password123',
+            'password_confirmation' => 'password123',
+        ]);
+
+        $response->assertRedirect(route('users.index'));
+        $response->assertSessionHas('success');
+    }
+
+    public function testStore_WhenEmailAlreadyExists_ShouldReturnValidationError(): void
+    {
+        $admin = User::factory()->create(['super_admin' => true, 'email' => 'existing@test.com']);
+
+        $response = $this->actingAs($admin)->post(route('users.store'), [
+            'name'                  => 'Other User',
+            'email'                 => 'existing@test.com',
+            'password'              => 'password123',
+            'password_confirmation' => 'password123',
+        ]);
+
+        $response->assertSessionHasErrors('email');
+    }
+
+    public function testStore_WhenPasswordTooShort_ShouldReturnValidationError(): void
+    {
+        $admin = User::factory()->create(['super_admin' => true]);
+
+        $response = $this->actingAs($admin)->post(route('users.store'), [
+            'name'                  => 'Test',
+            'email'                 => 'test@test.com',
+            'password'              => '1234567',
+            'password_confirmation' => '1234567',
+        ]);
+
+        $response->assertSessionHasErrors('password');
+    }
+
+    public function testStore_WhenPasswordNotConfirmed_ShouldReturnValidationError(): void
+    {
+        $admin = User::factory()->create(['super_admin' => true]);
+
+        $response = $this->actingAs($admin)->post(route('users.store'), [
+            'name'                  => 'Test',
+            'email'                 => 'test@test.com',
+            'password'              => 'password123',
+            'password_confirmation' => 'different123',
+        ]);
+
+        $response->assertSessionHasErrors('password');
+    }
+
+    // destroy
+
+    public function testDestroy_WhenUnauthenticated_ShouldRedirectToLogin(): void
+    {
+        $target = User::factory()->create();
+
+        $response = $this->delete(route('users.destroy', $target));
+
+        $response->assertRedirect(route('login.index'));
+    }
+
+    public function testDestroy_WhenAuthenticatedAsNonSuperAdmin_ShouldReturn403(): void
+    {
+        $user   = User::factory()->create(['super_admin' => false]);
+        $target = User::factory()->create();
+
+        $response = $this->actingAs($user)->delete(route('users.destroy', $target));
+
+        $response->assertStatus(403);
+    }
+
+    public function testDestroy_WhenAuthenticatedAsSuperAdmin_ShouldDeleteUser(): void
+    {
+        $admin  = User::factory()->create(['super_admin' => true]);
+        $target = User::factory()->create();
+
+        $this->actingAs($admin)->delete(route('users.destroy', $target));
+
+        $this->assertDatabaseMissing('users', ['id' => $target->id]);
+    }
+
+    public function testDestroy_WhenAuthenticatedAsSuperAdmin_ShouldRedirectWithSuccess(): void
+    {
+        $admin  = User::factory()->create(['super_admin' => true]);
+        $target = User::factory()->create();
+
+        $response = $this->actingAs($admin)->delete(route('users.destroy', $target));
+
+        $response->assertRedirect(route('users.index'));
+        $response->assertSessionHas('success');
+    }
+}


### PR DESCRIPTION
## Summary
- Cria `UserController` com actions `index`, `store` e `destroy`
- Cria middleware `SuperAdmin` para proteger as rotas
- Registra alias `super_admin` no `bootstrap/app.php`
- Adiciona rotas `/users` protegidas por `auth` + `super_admin`
- Adiciona link "Usuários" no observer para super admins
- Adiciona `@stack('js')` no layout `default.blade.php`

## Test plan
- [ ] Acessar `/users` como super admin — deve carregar a página
- [ ] Acessar `/users` sem autenticação — deve redirecionar para login
- [ ] Acessar `/users` como usuário não-admin — deve ser bloqueado

🤖 Generated with [Claude Code](https://claude.com/claude-code)