### PR TITLE
feat: gerenciamento de usuários - CSS

### DIFF
--- a/src/public/css/users.css
+++ b/src/public/css/users.css
@@ -1,0 +1,203 @@
+* {
+    box-sizing: border-box;
+    font-family: Arial, Helvetica, sans-serif;
+}
+
+body {
+    margin: 0;
+    background: #121212;
+    color: #e0e0e0;
+}
+
+.page {
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    padding: 40px 16px;
+}
+
+.container {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    width: 100%;
+    max-width: 600px;
+}
+
+.card {
+    padding: 24px;
+    background: #1e1e1e;
+    border-radius: 8px;
+    box-shadow: 0 6px 18px rgba(0,0,0,.6);
+}
+
+.card h2 {
+    margin: 0 0 20px;
+    font-size: 18px;
+}
+
+label {
+    display: block;
+    margin-bottom: 6px;
+    margin-top: 14px;
+    font-size: 13px;
+    color: #bdbdbd;
+}
+
+label:first-of-type {
+    margin-top: 0;
+}
+
+input[type="text"],
+input[type="password"] {
+    width: 100%;
+    padding: 10px;
+    background: #121212;
+    color: #fff;
+    border: 1px solid #333;
+    border-radius: 4px;
+    font-size: 14px;
+}
+
+input[type="text"]:focus,
+input[type="password"]:focus {
+    outline: none;
+    border-color: #90caf9;
+}
+
+.btn-save {
+    width: 100%;
+    margin-top: 20px;
+    padding: 10px;
+    background: #1976d2;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    font-size: 14px;
+    cursor: pointer;
+    transition: background .2s ease;
+}
+
+.btn-save:hover {
+    background: #1e88e5;
+}
+
+.alert-success {
+    padding: 10px 12px;
+    margin-bottom: 16px;
+    background: #1b5e20;
+    color: #a5d6a7;
+    border-radius: 4px;
+    font-size: 13px;
+}
+
+.alert-error {
+    padding: 10px 12px;
+    margin-bottom: 16px;
+    background: #4e1111;
+    color: #ef9a9a;
+    border-radius: 4px;
+    font-size: 13px;
+    line-height: 1.6;
+}
+
+/* Users table */
+.users-list table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+}
+
+.users-list th {
+    text-align: left;
+    padding: 8px 10px;
+    color: #9e9e9e;
+    border-bottom: 1px solid #333;
+}
+
+.users-list td {
+    padding: 10px;
+    border-bottom: 1px solid #2a2a2a;
+    vertical-align: middle;
+}
+
+.users-list tr:last-child td {
+    border-bottom: none;
+}
+
+.btn-delete {
+    padding: 4px 10px;
+    background: #b71c1c;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    font-size: 12px;
+    cursor: pointer;
+    transition: background .2s ease;
+}
+
+.btn-delete:hover {
+    background: #c62828;
+}
+
+.empty-msg {
+    font-size: 13px;
+    color: #666;
+    margin: 0;
+}
+
+.password-row {
+    display: flex;
+    gap: 8px;
+}
+
+.password-wrap {
+    position: relative;
+    flex: 1;
+}
+
+.password-wrap input {
+    width: 100%;
+    padding-right: 38px;
+}
+
+.btn-eye {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    color: #9e9e9e;
+    display: flex;
+    align-items: center;
+}
+
+.btn-eye:hover {
+    color: #e0e0e0;
+}
+
+.eye-icon,
+.eye-off-icon {
+    width: 18px;
+    height: 18px;
+}
+
+.btn-gen {
+    padding: 0 14px;
+    background: #37474f;
+    color: #e0e0e0;
+    border: 1px solid #555;
+    border-radius: 4px;
+    font-size: 13px;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background .2s ease;
+}
+
+.btn-gen:hover {
+    background: #546e7a;
+}


### PR DESCRIPTION
## Summary
- Adiciona `users.css` com estilos completos da tela de gerenciamento de usuários
- Inclui estilos para formulário, tabela, alertas, botões e componentes de senha (`password-row`, `password-wrap`, `btn-eye`)

> Depende do PR #19

## Test plan
- [ ] Verificar que o layout do formulário está correto
- [ ] Verificar ícone de olho posicionado corretamente nos campos de senha
- [ ] Verificar responsividade em telas menores

🤖 Generated with [Claude Code](https://claude.com/claude-code)