### PR TITLE
feat: adiciona endpoint de healthcheck do crawler

### DIFF
--- a/src/app/Http/Controllers/HomeController.php
+++ b/src/app/Http/Controllers/HomeController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\ExecutionCrawler;
 use App\Setting\SettingService;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
@@ -79,5 +80,15 @@ class HomeController extends Controller {
 
     public function refil(): View {
         return view('refil');
+    }
+
+    public function healthcheck(): JsonResponse {
+        $lastExecution = ExecutionCrawler::latest()->first();
+
+        if ($lastExecution && $lastExecution->created_at->diffInSeconds(now()) < 60) {
+            return response()->json(['status' => 'ok'], 200);
+        }
+
+        return response()->json(['status' => 'error'], 500);
     }
 }

--- a/src/app/Models/ExecutionCrawler.php
+++ b/src/app/Models/ExecutionCrawler.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -15,5 +16,5 @@ use Illuminate\Database\Eloquent\Model;
  * @property float $request_time
  */
 class ExecutionCrawler extends Model {
-
+    use HasFactory;
 }

--- a/src/database/factories/ExecutionCrawlerFactory.php
+++ b/src/database/factories/ExecutionCrawlerFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ExecutionCrawlerFactory extends Factory {
+
+    public function definition(): array {
+        return [
+            'guild_name' => $this->faker->word(),
+            'url' => $this->faker->url(),
+            'qtd_characters' => $this->faker->numberBetween(1, 100),
+            'qtd_character_online' => $this->faker->numberBetween(0, 50),
+            'qtd_character_offline' => $this->faker->numberBetween(0, 50),
+            'execution_time' => $this->faker->numberBetween(1, 10),
+            'scraping_time' => $this->faker->randomFloat(2, 0.1, 5.0),
+            'request_time' => $this->faker->randomFloat(2, 0.1, 5.0),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+    }
+
+    public function recentExecution(): static {
+        return $this->state(['created_at' => now()->subSeconds(30)]);
+    }
+
+    public function outdatedExecution(): static {
+        return $this->state(['created_at' => now()->subSeconds(90)]);
+    }
+}

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -10,6 +10,7 @@ Route::post('/login', [LoginController::class, 'login'])->name('login');
 Route::get('/', [HomeController::class, 'index'])->name('home');
 Route::get('/get-online-characters', [HomeController::class, 'getOnlineCharacters'])->name('get-online-characters');
 Route::get('/refil', [HomeController::class, 'refil'])->name('refil');
+Route::get('/healthcheck', [HomeController::class, 'healthcheck'])->name('healthcheck');
 
 Route::middleware(['auth'])->group(function () {
     Route::get('/admin', [HomeController::class, 'index'])->name('admin.home');

--- a/src/tests/Feature/App/Http/Controllers/HomeControllerTest.php
+++ b/src/tests/Feature/App/Http/Controllers/HomeControllerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\App\Http\Controllers;
 
 use App\Models\Character;
+use App\Models\ExecutionCrawler;
 use App\Models\Setting;
 use App\Models\User;
 use App\Setting\SettingConfig;
@@ -127,5 +128,30 @@ class HomeControllerTest extends TestCase {
 
         $response->assertStatus(200);
         $response->assertViewIs('refil');
+    }
+
+    public function testHealthcheck_WhenLastExecutionWasLessThanOneMinuteAgo_ShouldReturn200(): void {
+        ExecutionCrawler::factory()->recentExecution()->create();
+
+        $response = $this->getJson(route('healthcheck'));
+
+        $response->assertStatus(200);
+        $response->assertJson(['status' => 'ok']);
+    }
+
+    public function testHealthcheck_WhenLastExecutionWasMoreThanOneMinuteAgo_ShouldReturn500(): void {
+        ExecutionCrawler::factory()->outdatedExecution()->create();
+
+        $response = $this->getJson(route('healthcheck'));
+
+        $response->assertStatus(500);
+        $response->assertJson(['status' => 'error']);
+    }
+
+    public function testHealthcheck_WhenNoCrawlerExecutionExists_ShouldReturn500(): void {
+        $response = $this->getJson(route('healthcheck'));
+
+        $response->assertStatus(500);
+        $response->assertJson(['status' => 'error']);
     }
 }


### PR DESCRIPTION
## Summary
- Adiciona `GET /healthcheck` que retorna **200** quando a última execução do crawler ocorreu há menos de 1 minuto
- Retorna **500** caso não haja registros ou a execução tenha ocorrido há 1 minuto ou mais
- Adiciona `HasFactory` ao model `ExecutionCrawler` e cria `ExecutionCrawlerFactory`

## Test plan
- [ ] `GET /healthcheck` retorna 200 com `{"status":"ok"}` quando último crawler foi há menos de 60s
- [ ] `GET /healthcheck` retorna 500 com `{"status":"error"}` quando último crawler foi há mais de 60s
- [ ] `GET /healthcheck` retorna 500 com `{"status":"error"}` quando não há registros de execução

🤖 Generated with [Claude Code](https://claude.com/claude-code)