### PR TITLE
test: testes de cobertura do GuildPage - parte 1

### DIFF
--- a/src/tests/Feature/App/Scrapers/GuildPageTest.php
+++ b/src/tests/Feature/App/Scrapers/GuildPageTest.php
@@ -80,6 +80,141 @@ class GuildPageTest extends TestCase {
         $this->assertDatabaseCount('characters', 0);
     }
 
+    public function testScrap_WhenTrHasLabelHClass_ShouldSkipRow(): void {
+        $html = GuildPageHtml::onlyLabelHRow();
+
+        GuildPage::getInstance($html, GuildEnum::OUTLAW->value)->scrap();
+
+        $this->assertDatabaseCount('characters', 0);
+    }
+
+    public function testScrap_WhenTrHasDoNotBreakClass_ShouldSkipInvitationBoardRow(): void {
+        $html = GuildPageHtml::withDoNotBreakRow();
+
+        GuildPage::getInstance($html, GuildEnum::OUTLAW->value)->scrap();
+
+        $this->assertDatabaseCount('characters', 0);
+    }
+
+    public function testScrap_WhenTrContainsNoInvitedCharactersText_ShouldSkipRow(): void {
+        $html = GuildPageHtml::withNoInvitedCharactersText();
+
+        GuildPage::getInstance($html, GuildEnum::OUTLAW->value)->scrap();
+
+        $this->assertDatabaseCount('characters', 0);
+    }
+
+    public function testScrap_WhenHtmlHasNoRows_ShouldReturnEarlyWithoutUpdatingDatabase(): void {
+        $databaseCharacter = Character::factory()->create([
+            'is_online' => true,
+            'guild_name' => GuildEnum::OUTLAW->value,
+        ]);
+
+        GuildPage::getInstance(GuildPageHtml::emptyTable(), GuildEnum::OUTLAW->value)->scrap();
+
+        $databaseCharacter->refresh();
+        $this->assertTrue($databaseCharacter->is_online);
+    }
+
+    public function testScrap_WhenPlayerIsOnlineInHtml_AndDoesNotExistInDatabase_ShouldCreateCharacterAndMarkAsOnline(): void {
+        Carbon::setTestNow(Carbon::now());
+        $guildPageCharacter = new GuildPageCharacter();
+        $guildPageCharacter->rank = 'Leader';
+        $guildPageCharacter->name = 'New Character';
+        $guildPageCharacter->vocation = VocationEnum::EK;
+        $guildPageCharacter->level = '500';
+        $guildPageCharacter->joining_date = Carbon::now();
+        $guildPageCharacter->is_online = true;
+
+        $html = GuildPageHtml::listOfCharacters($guildPageCharacter);
+
+        GuildPage::getInstance($html, GuildEnum::OUTLAW->value)->scrap();
+
+        $this->assertDatabaseCount('characters', 1);
+        $created = Character::where('name', 'New Character')->first();
+        $this->assertTrue($created->is_online);
+    }
+
+    public function testScrap_WhenPlayerIsOnlineInHtml_AndExistsInDatabaseWithDifferentGuild_ShouldReuseExistingCharacterAndMarkAsOnline(): void {
+        Carbon::setTestNow(Carbon::now());
+        $guildPageCharacter = new GuildPageCharacter();
+        $guildPageCharacter->rank = 'Leader';
+        $guildPageCharacter->name = 'Fabio Selokoo';
+        $guildPageCharacter->vocation = VocationEnum::EK;
+        $guildPageCharacter->level = '1264';
+        $guildPageCharacter->joining_date = Carbon::now();
+        $guildPageCharacter->is_online = true;
+        Character::factory()->create([
+            'name' => $guildPageCharacter->name,
+            'vocation' => $guildPageCharacter->vocation,
+            'level' => $guildPageCharacter->level,
+            'joining_date' => $guildPageCharacter->joining_date,
+            'is_online' => false,
+            'guild_name' => GuildEnum::QUELIBRALAND->value,
+        ]);
+
+        $html = GuildPageHtml::listOfCharacters($guildPageCharacter);
+
+        GuildPage::getInstance($html, GuildEnum::OUTLAW->value)->scrap();
+
+        $this->assertDatabaseCount('characters', 1);
+        $character = Character::where('name', $guildPageCharacter->name)->first();
+        $this->assertTrue($character->is_online);
+    }
+
+    public function testScrap_WhenPlayerIsAlreadyOnlineInDatabase_AndIsOnlineOnHtml_ShouldKeepOriginalOnlineAt(): void {
+        $originalOnlineAt = Carbon::now()->subHour();
+        $guildPageCharacter = new GuildPageCharacter();
+        $guildPageCharacter->rank = 'Leader';
+        $guildPageCharacter->name = 'Fabio Selokoo';
+        $guildPageCharacter->vocation = VocationEnum::EK;
+        $guildPageCharacter->level = '1264';
+        $guildPageCharacter->joining_date = Carbon::now();
+        $guildPageCharacter->is_online = true;
+        $databaseCharacter = Character::factory()->create([
+            'name' => $guildPageCharacter->name,
+            'vocation' => $guildPageCharacter->vocation,
+            'level' => $guildPageCharacter->level,
+            'joining_date' => $guildPageCharacter->joining_date,
+            'is_online' => true,
+            'online_at' => $originalOnlineAt,
+            'guild_name' => GuildEnum::OUTLAW->value,
+        ]);
+
+        $html = GuildPageHtml::listOfCharacters($guildPageCharacter);
+
+        GuildPage::getInstance($html, GuildEnum::OUTLAW->value)->scrap();
+
+        $databaseCharacter->refresh();
+        $this->assertEquals($originalOnlineAt->toDateTimeString(), $databaseCharacter->online_at->toDateTimeString());
+    }
+
+    public function testScrap_WhenPlayerIsOfflineInDatabase_AndDoesNotExistInHtml_ShouldDeleteFromDatabase(): void {
+        Character::factory()->create([
+            'name' => 'Ghost Player',
+            'guild_name' => GuildEnum::OUTLAW->value,
+            'is_online' => false,
+        ]);
+        $guildPageCharacter = new GuildPageCharacter();
+        $guildPageCharacter->rank = 'Leader';
+        $guildPageCharacter->name = 'Fabio Selokoo';
+        $guildPageCharacter->vocation = VocationEnum::EK;
+        $guildPageCharacter->level = '1264';
+        $guildPageCharacter->joining_date = Carbon::now();
+        $guildPageCharacter->is_online = false;
+        Character::factory()->create([
+            'name' => $guildPageCharacter->name,
+            'guild_name' => GuildEnum::OUTLAW->value,
+            'is_online' => false,
+        ]);
+
+        $html = GuildPageHtml::listOfCharacters($guildPageCharacter);
+
+        GuildPage::getInstance($html, GuildEnum::OUTLAW->value)->scrap();
+
+        $this->assertNull(Character::where('name', 'Ghost Player')->first());
+    }
+
     public function testScrap_WhenPlayerIsOnlineInDatabase_AndDidntExistsInHtml_ShouldMarkAsOfflineAndDeleteFromDatabase() {
         Carbon::setTestNow($expectedOnlineAt = Carbon::now());
         $guildPageCharacter = new GuildPageCharacter();

--- a/src/tests/Support/GuildPageHtml.php
+++ b/src/tests/Support/GuildPageHtml.php
@@ -55,6 +55,94 @@ HTML;
 HTML;
     }
 
+    public static function listOfMultipleCharacters(array $characters): string {
+        $rows = implode('', array_map(fn($c) => self::buildCharacterRow($c), $characters));
+        $html = <<<HTML
+        <div id="guilds">
+            <div class="TableContainer">
+                <table class="TableContent">
+                    <tr class="LabelH">
+                        <td>Rank</td>
+                        <td>Name and Title</td>
+                        <td>Vocation</td>
+                        <td>Level</td>
+                        <td>Joining Date</td>
+                        <td>Status</td>
+                    </tr>
+                    $rows
+                </table>
+            </div>
+        </div>
+HTML;
+        return $html;
+    }
+
+    public static function onlyLabelHRow(): string {
+        return <<<HTML
+        <div id="guilds">
+            <div class="TableContainer">
+                <table class="TableContent">
+                    <tr class="LabelH">
+                        <td>Rank</td>
+                        <td>Name and Title</td>
+                        <td>Vocation</td>
+                        <td>Level</td>
+                        <td>Joining Date</td>
+                        <td>Status</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+HTML;
+    }
+
+    public static function withDoNotBreakRow(): string {
+        return <<<HTML
+        <div id="guilds">
+            <div class="TableContainer">
+                <table class="TableContent">
+                    <tr class="LabelH">
+                        <td>Rank</td><td>Name</td><td>Vocation</td><td>Level</td><td>Joining Date</td><td>Status</td>
+                    </tr>
+                    <tr>
+                        <td class="DoNotBreak">Invited Character</td>
+                        <td>col2</td><td>col3</td><td>col4</td><td>col5</td><td>col6</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+HTML;
+    }
+
+    public static function withNoInvitedCharactersText(): string {
+        return <<<HTML
+        <div id="guilds">
+            <div class="TableContainer">
+                <table class="TableContent">
+                    <tr class="LabelH">
+                        <td>Rank</td><td>Name</td><td>Vocation</td><td>Level</td><td>Joining Date</td><td>Status</td>
+                    </tr>
+                    <tr bgcolor="#F1E0C6">
+                        <td>No invited characters</td>
+                        <td>col2</td><td>col3</td><td>col4</td><td>col5</td><td>col6</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+HTML;
+    }
+
+    public static function emptyTable(): string {
+        return <<<HTML
+        <div id="guilds">
+            <div class="TableContainer">
+                <table class="TableContent">
+                </table>
+            </div>
+        </div>
+HTML;
+    }
+
     public static function listOfCharactersWithInvalidTdCount(): string {
         $invalidRow = '<tr bgcolor="#F1E0C6"><td>Leader</td><td>Only Four</td><td>Knight</td><td>100</td></tr>';
         $html = <<<HTML


### PR DESCRIPTION
## Summary

- Adiciona 5 novos métodos de fixture em `GuildPageHtml` (`onlyLabelHRow`, `withDoNotBreakRow`, `withNoInvitedCharactersText`, `emptyTable`, `listOfMultipleCharacters`)
- Adiciona 8 novos testes em `GuildPageTest` cobrindo: filtros de linha (LabelH, DoNotBreak, texto "No invited characters"), retorno antecipado com HTML sem linhas, criação de personagem novo, reutilização de registro de outra guild, preservação do `online_at` e remoção de personagem que saiu da guild

## Test plan

- [x] `testScrap_WhenTrHasLabelHClass_ShouldSkipRow`
- [x] `testScrap_WhenTrHasDoNotBreakClass_ShouldSkipInvitationBoardRow`
- [x] `testScrap_WhenTrContainsNoInvitedCharactersText_ShouldSkipRow`
- [x] `testScrap_WhenHtmlHasNoRows_ShouldReturnEarlyWithoutUpdatingDatabase`
- [x] `testScrap_WhenPlayerIsOnlineInHtml_AndDoesNotExistInDatabase_ShouldCreateCharacterAndMarkAsOnline`
- [x] `testScrap_WhenPlayerIsOnlineInHtml_AndExistsInDatabaseWithDifferentGuild_ShouldReuseExistingCharacterAndMarkAsOnline`
- [x] `testScrap_WhenPlayerIsAlreadyOnlineInDatabase_AndIsOnlineOnHtml_ShouldKeepOriginalOnlineAt`
- [x] `testScrap_WhenPlayerIsOfflineInDatabase_AndDoesNotExistInHtml_ShouldDeleteFromDatabase`

🤖 Generated with [Claude Code](https://claude.com/claude-code)