### PR TITLE
feat: Etapa 3 - Criar evento OnlineCharactersUpdated para broadcast

### DIFF
--- a/src/app/Events/OnlineCharactersUpdated.php
+++ b/src/app/Events/OnlineCharactersUpdated.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+
+class OnlineCharactersUpdated implements ShouldBroadcast {
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public readonly Collection $characters,
+        public readonly string $guildName,
+    ) {}
+
+    public function broadcastOn(): Channel {
+        return new Channel("online-characters.{$this->guildName}");
+    }
+
+    public function broadcastWith(): array {
+        return [
+            'onlineCharacters' => $this->characters->toArray(),
+        ];
+    }
+}

--- a/src/tests/Unit/App/Events/OnlineCharactersUpdatedTest.php
+++ b/src/tests/Unit/App/Events/OnlineCharactersUpdatedTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Unit\App\Events;
+
+use App\Events\OnlineCharactersUpdated;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\TestCase;
+
+class OnlineCharactersUpdatedTest extends TestCase {
+
+    public function testBroadcastOn_ShouldReturnPublicChannelWithGuildName(): void {
+        $event = new OnlineCharactersUpdated(collect([]), 'TestGuild');
+
+        $channel = $event->broadcastOn();
+
+        $this->assertInstanceOf(Channel::class, $channel);
+        $this->assertEquals('online-characters.TestGuild', $channel->name);
+    }
+
+    public function testBroadcastOn_ShouldIncludeGuildNameInChannelName(): void {
+        $event = new OnlineCharactersUpdated(collect([]), 'AnotherGuild');
+
+        $channel = $event->broadcastOn();
+
+        $this->assertEquals('online-characters.AnotherGuild', $channel->name);
+    }
+
+    public function testBroadcastWith_ShouldReturnOnlineCharactersKey(): void {
+        $character = ['name' => 'TestChar', 'is_online' => true, 'vocation' => 'Knight', 'level' => 100];
+        $event = new OnlineCharactersUpdated(collect([$character]), 'TestGuild');
+
+        $data = $event->broadcastWith();
+
+        $this->assertArrayHasKey('onlineCharacters', $data);
+        $this->assertCount(1, $data['onlineCharacters']);
+        $this->assertEquals('TestChar', $data['onlineCharacters'][0]['name']);
+    }
+
+    public function testBroadcastWith_WhenEmptyCollection_ShouldReturnEmptyOnlineCharacters(): void {
+        $event = new OnlineCharactersUpdated(collect([]), 'TestGuild');
+
+        $data = $event->broadcastWith();
+
+        $this->assertArrayHasKey('onlineCharacters', $data);
+        $this->assertEmpty($data['onlineCharacters']);
+    }
+
+    public function testBroadcastWith_ShouldIncludeAllCharacterFields(): void {
+        $character = [
+            'name' => 'TestChar',
+            'is_online' => true,
+            'vocation' => 'Knight',
+            'level' => 100,
+        ];
+        $event = new OnlineCharactersUpdated(collect([$character]), 'TestGuild');
+
+        $data = $event->broadcastWith();
+
+        $charData = $data['onlineCharacters'][0];
+        $this->assertEquals('TestChar', $charData['name']);
+        $this->assertEquals('Knight', $charData['vocation']);
+        $this->assertEquals(100, $charData['level']);
+        $this->assertTrue($charData['is_online']);
+    }
+
+    public function testBroadcastWith_ShouldPreserveMultipleCharacters(): void {
+        $characters = [
+            ['name' => 'CharOne', 'is_online' => true],
+            ['name' => 'CharTwo', 'is_online' => true],
+            ['name' => 'CharThree', 'is_online' => false],
+        ];
+        $event = new OnlineCharactersUpdated(collect($characters), 'TestGuild');
+
+        $data = $event->broadcastWith();
+
+        $this->assertCount(3, $data['onlineCharacters']);
+    }
+}


### PR DESCRIPTION
## Summary

- Cria `app/Events/OnlineCharactersUpdated` implementando `ShouldBroadcast`
- O evento transmite personagens online em canal público `online-characters.{guildName}`, segmentado por guild
- Adiciona 6 testes unitários cobrindo `broadcastOn()` e `broadcastWith()`

## Relacionado

Fecha parte de #5 (Etapa 3 de 8)

## Test plan

- [x] `testBroadcastOn_ShouldReturnPublicChannelWithGuildName`
- [x] `testBroadcastOn_ShouldIncludeGuildNameInChannelName`
- [x] `testBroadcastWith_ShouldReturnOnlineCharactersKey`
- [x] `testBroadcastWith_WhenEmptyCollection_ShouldReturnEmptyOnlineCharacters`
- [x] `testBroadcastWith_ShouldIncludeAllCharacterFields`
- [x] `testBroadcastWith_ShouldPreserveMultipleCharacters`

🤖 Generated with [Claude Code](https://claude.com/claude-code)