### PR TITLE
feat: Etapa 5 - Definir o canal de broadcast

### DIFF
--- a/src/bootstrap/app.php
+++ b/src/bootstrap/app.php
@@ -8,6 +8,7 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
         commands: __DIR__.'/../routes/console.php',
+        channels: __DIR__.'/../routes/channels.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {

--- a/src/routes/channels.php
+++ b/src/routes/channels.php
@@ -1,0 +1,7 @@
+<?php
+
+use Illuminate\Support\Facades\Broadcast;
+
+Broadcast::channel('online-characters.{guildName}', function () {
+    return true;
+});

--- a/src/tests/Feature/App/Channels/OnlineCharactersChannelTest.php
+++ b/src/tests/Feature/App/Channels/OnlineCharactersChannelTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Feature\App\Channels;
+
+use Tests\TestCase;
+
+class OnlineCharactersChannelTest extends TestCase {
+
+    public function testOnlineCharactersChannel_ShouldAllowPublicAccess(): void {
+        $response = $this->withoutMiddleware()->postJson('/broadcasting/auth', [
+            'channel_name' => 'online-characters.TestGuild',
+            'socket_id' => '1234.5678',
+        ]);
+
+        $response->assertStatus(200);
+    }
+
+    public function testOnlineCharactersChannel_WithDifferentGuildName_ShouldBeAccessible(): void {
+        $response = $this->withoutMiddleware()->postJson('/broadcasting/auth', [
+            'channel_name' => 'online-characters.AnotherGuild',
+            'socket_id' => '1234.5678',
+        ]);
+
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Summary
- Cria `routes/channels.php` com o canal público `online-characters.{guildName}` registrado via `Broadcast::channel()` retornando `true`
- Registra o arquivo `channels.php` no `bootstrap/app.php` via `->withRouting(channels: ...)`
- Adiciona testes de feature em `OnlineCharactersChannelTest` verificando que o canal é publicamente acessível para qualquer nome de guild

## Test plan
- [ ] `OnlineCharactersChannelTest::testOnlineCharactersChannel_ShouldAllowPublicAccess` — verifica acesso ao canal `online-characters.TestGuild`
- [ ] `OnlineCharactersChannelTest::testOnlineCharactersChannel_WithDifferentGuildName_ShouldBeAccessible` — verifica acesso com nome de guild diferente

Closes parte da #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)