### PR TITLE
feat: Etapa 6 - Instalar o Laravel Echo no frontend

### DIFF
--- a/src/bootstrap/app.php
+++ b/src/bootstrap/app.php
@@ -8,6 +8,7 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
         commands: __DIR__.'/../routes/console.php',
+        channels: __DIR__.'/../routes/channels.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -9,7 +9,9 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "puppeteer": "^24.16.0"
+                "laravel-echo": "^2.3.1",
+                "puppeteer": "^24.16.0",
+                "pusher-js": "^8.4.0"
             },
             "devDependencies": {
                 "@tailwindcss/vite": "^4.0.0",
@@ -852,6 +854,13 @@
                 "win32"
             ]
         },
+        "node_modules/@socket.io/component-emitter": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+            "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/@tailwindcss/node": {
             "version": "4.1.11",
             "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.11.tgz",
@@ -1597,6 +1606,30 @@
                 "once": "^1.4.0"
             }
         },
+        "node_modules/engine.io-client": {
+            "version": "6.6.4",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
+            "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@socket.io/component-emitter": "~3.1.0",
+                "debug": "~4.4.1",
+                "engine.io-parser": "~5.2.1",
+                "ws": "~8.18.3",
+                "xmlhttprequest-ssl": "~2.1.1"
+            }
+        },
+        "node_modules/engine.io-parser": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+            "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/enhanced-resolve": {
             "version": "5.18.3",
             "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
@@ -2152,6 +2185,19 @@
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "license": "MIT"
+        },
+        "node_modules/laravel-echo": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/laravel-echo/-/laravel-echo-2.3.1.tgz",
+            "integrity": "sha512-o6oD1oR+XklU9TO7OPGeLh/G9SjcZm+YrpSdGkOaAJf5HpXwZKt+wGgnULvKl5I8xUuUY/AAvqR24+y8suwZTA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "peerDependencies": {
+                "pusher-js": "*",
+                "socket.io-client": "*"
+            }
         },
         "node_modules/laravel-vite-plugin": {
             "version": "1.3.0",
@@ -2763,6 +2809,15 @@
                 "node": ">=18"
             }
         },
+        "node_modules/pusher-js": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/pusher-js/-/pusher-js-8.4.0.tgz",
+            "integrity": "sha512-wp3HqIIUc1GRyu1XrP6m2dgyE9MoCsXVsWNlohj0rjSkLf+a0jLvEyVubdg58oMk7bhjBWnFClgp8jfAa6Ak4Q==",
+            "license": "MIT",
+            "dependencies": {
+                "tweetnacl": "^1.0.3"
+            }
+        },
         "node_modules/require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -2864,6 +2919,36 @@
             "engines": {
                 "node": ">= 6.0.0",
                 "npm": ">= 3.0.0"
+            }
+        },
+        "node_modules/socket.io-client": {
+            "version": "4.8.3",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+            "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@socket.io/component-emitter": "~3.1.0",
+                "debug": "~4.4.1",
+                "engine.io-client": "~6.6.1",
+                "socket.io-parser": "~4.2.4"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/socket.io-parser": {
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.5.tgz",
+            "integrity": "sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@socket.io/component-emitter": "~3.1.0",
+                "debug": "~4.4.1"
+            },
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/socks": {
@@ -3077,6 +3162,12 @@
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "license": "0BSD"
         },
+        "node_modules/tweetnacl": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+            "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+            "license": "Unlicense"
+        },
         "node_modules/typed-query-selector": {
             "version": "2.12.0",
             "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
@@ -3231,6 +3322,15 @@
                 "utf-8-validate": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/xmlhttprequest-ssl": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+            "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+            "peer": true,
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/y18n": {

--- a/src/package.json
+++ b/src/package.json
@@ -24,6 +24,8 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "puppeteer": "^24.16.0"
+        "laravel-echo": "^2.3.1",
+        "puppeteer": "^24.16.0",
+        "pusher-js": "^8.4.0"
     }
 }

--- a/src/resources/js/bootstrap.js
+++ b/src/resources/js/bootstrap.js
@@ -2,3 +2,18 @@ import axios from 'axios';
 window.axios = axios;
 
 window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+
+import Echo from 'laravel-echo';
+import Pusher from 'pusher-js';
+
+window.Pusher = Pusher;
+
+window.Echo = new Echo({
+    broadcaster: 'reverb',
+    key: import.meta.env.VITE_REVERB_APP_KEY,
+    wsHost: import.meta.env.VITE_REVERB_HOST,
+    wsPort: import.meta.env.VITE_REVERB_PORT ?? 80,
+    wssPort: import.meta.env.VITE_REVERB_PORT ?? 443,
+    forceTLS: (import.meta.env.VITE_REVERB_SCHEME ?? 'https') === 'https',
+    enabledTransports: ['ws', 'wss'],
+});

--- a/src/routes/channels.php
+++ b/src/routes/channels.php
@@ -1,0 +1,7 @@
+<?php
+
+use Illuminate\Support\Facades\Broadcast;
+
+Broadcast::channel('online-characters.{guildName}', function () {
+    return true;
+});

--- a/src/tests/Feature/App/Channels/OnlineCharactersChannelTest.php
+++ b/src/tests/Feature/App/Channels/OnlineCharactersChannelTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Feature\App\Channels;
+
+use Tests\TestCase;
+
+class OnlineCharactersChannelTest extends TestCase {
+
+    public function testOnlineCharactersChannel_ShouldAllowPublicAccess(): void {
+        $response = $this->withoutMiddleware()->postJson('/broadcasting/auth', [
+            'channel_name' => 'online-characters.TestGuild',
+            'socket_id' => '1234.5678',
+        ]);
+
+        $response->assertStatus(200);
+    }
+
+    public function testOnlineCharactersChannel_WithDifferentGuildName_ShouldBeAccessible(): void {
+        $response = $this->withoutMiddleware()->postJson('/broadcasting/auth', [
+            'channel_name' => 'online-characters.AnotherGuild',
+            'socket_id' => '1234.5678',
+        ]);
+
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Summary
- Instala `laravel-echo` e `pusher-js` via npm como dependências do projeto
- Configura o `window.Echo` no `bootstrap.js` usando o broadcaster `reverb` com as variáveis de ambiente `VITE_REVERB_*`
- Expõe `window.Pusher` necessário para o Echo funcionar internamente

## Test plan
- [ ] Verificar que `npm run build` conclui sem erros
- [ ] Verificar que `window.Echo` está disponível no console do browser após o build
- [ ] Verificar que o Echo tenta conectar ao host/porta definidos nas variáveis VITE_REVERB_*

Closes #5 (parte da etapa 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)