### PR TITLE
feat: adiciona variáveis de ambiente do Reverb ao container app

### DIFF
--- a/infra/app_web/docker-compose.yml
+++ b/infra/app_web/docker-compose.yml
@@ -31,6 +31,12 @@ services:
       - APP_URL=${APP_URL}
       - APP_KEY=${APP_KEY}
       - XDEBUG_MODE=off
+      - REVERB_APP_ID=${REVERB_APP_ID}
+      - REVERB_APP_KEY=${REVERB_APP_KEY}
+      - REVERB_APP_SECRET=${REVERB_APP_SECRET}
+      - REVERB_HOST=${REVERB_HOST}
+      - REVERB_PORT=${REVERB_PORT}
+      - REVERB_SCHEME=${REVERB_SCHEME}
     networks:
       - laravel
     restart: always


### PR DESCRIPTION
## Summary

- Adiciona `REVERB_APP_ID`, `REVERB_APP_KEY`, `REVERB_APP_SECRET`, `REVERB_HOST`, `REVERB_PORT` e `REVERB_SCHEME` ao serviço `app` no `docker-compose.yml`
- O container `app` precisava dessas variáveis para que o broadcast de eventos via requisições web seja roteado corretamente ao servidor Reverb

## Test plan

- [ ] Restartar o container `app`: `docker compose -f infra/app_web/docker-compose.yml up -d --force-recreate app`
- [ ] Verificar as vars no container: `docker exec app_web-app-1 printenv | grep REVERB`

🤖 Generated with [Claude Code](https://claude.com/claude-code)