### PR TITLE
feat: broadcast incremental via diff (backend + frontend)

### DIFF
--- a/src/app/Character/CharacterService.php
+++ b/src/app/Character/CharacterService.php
@@ -73,4 +73,33 @@ readonly class CharacterService {
     public function findCharacterByName(string $name): ?Character {
         return $this->databaseCharacterRepository->firstCharacterByName($name);
     }
+
+    public function computeDiff(Collection $previous, Collection $current): array {
+        $previousByName = $previous->keyBy('name');
+        $currentByName = $current->keyBy('name');
+
+        $changes = $current->filter(function (array $character) use ($previousByName): bool {
+            $name = $character['name'];
+            if (!$previousByName->has($name)) {
+                return true;
+            }
+            return $this->characterHasChanged($previousByName->get($name), $character);
+        })->values()->toArray();
+
+        $removed = $previousByName->keys()
+            ->filter(fn(string $name) => !$currentByName->has($name))
+            ->values()
+            ->toArray();
+
+        return ['changes' => $changes, 'removed' => $removed];
+    }
+
+    private function characterHasChanged(array $previous, array $current): bool {
+        foreach (['is_online', 'position', 'position_time', 'level', 'type', 'is_attacker_character', 'online_at', 'offline_at'] as $field) {
+            if (($previous[$field] ?? null) !== ($current[$field] ?? null)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/app/Console/Commands/WorldScraper.php
+++ b/src/app/Console/Commands/WorldScraper.php
@@ -2,12 +2,14 @@
 
 namespace App\Console\Commands;
 
+use App\Character\CharacterService;
 use App\Events\OnlineCharactersUpdated;
 use App\Models\ExecutionCrawler;
 use App\Scrapers\GuildPage;
 use App\Setting\SettingService;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 
 class WorldScraper extends Command {
@@ -16,6 +18,10 @@ class WorldScraper extends Command {
     protected $description = 'Guild Page Scraper';
     private float $requestTime;
     private float $scrapTime;
+
+    public function __construct(private readonly CharacterService $characterService) {
+        parent::__construct();
+    }
 
     public function handle(): void {
         try {
@@ -34,14 +40,21 @@ class WorldScraper extends Command {
             $url = 'https://www.tibia.com/community/?' . http_build_query($params);
             $html = $this->dispatchRequest($url);
             $guildPage = $this->scrapPage($html, $searchGuild);
-            OnlineCharactersUpdated::dispatch($guildPage->onlineCharacters, $searchGuild);
+            $characters = $this->characterService->retrieveOnlinePlayers($searchGuild);
+            $currentData = $characters->map(fn($c) => $c instanceof \App\Models\Character ? $c->toArray() : (array) $c)->values();
 
+            $cacheKey = "broadcast_state_{$searchGuild}";
+            $previous = collect(Cache::get($cacheKey, []));
+            $diff = $this->characterService->computeDiff($previous, $currentData);
+            Cache::put($cacheKey, $currentData->toArray(), now()->addMinute());
+
+            OnlineCharactersUpdated::dispatch($diff['changes'], $diff['removed'], $searchGuild);
             $globalExecutionEnd = microtime(true);
             $executionTime = $globalExecutionEnd - $globalExecutionBegin;
 
             $this->info('Guild Page Scraped Summary: '.Carbon::now()->toDateTimeString());
             $this->info('Total Characters: '. $guildPage->getOnlineCharacters()+$guildPage->getOfflineCharacters());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->info('Error to execute: '.Carbon::now()->toDateTimeString());
             Log::info($e->getMessage());
         } finally {

--- a/src/app/Events/OnlineCharactersUpdated.php
+++ b/src/app/Events/OnlineCharactersUpdated.php
@@ -4,26 +4,28 @@ namespace App\Events;
 
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
 
-class OnlineCharactersUpdated implements ShouldBroadcast {
+class OnlineCharactersUpdated implements ShouldBroadcastNow {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
     public function __construct(
-        public readonly Collection $characters,
+        public readonly array $changes,
+        public readonly array $removed,
         public readonly string $guildName,
     ) {}
 
     public function broadcastOn(): Channel {
-        return new Channel("online-characters.{$this->guildName}");
+        return new Channel('online-characters');
     }
 
     public function broadcastWith(): array {
         return [
-            'onlineCharacters' => $this->characters->toArray(),
+            'changes' => $this->changes,
+            'removed' => $this->removed,
         ];
     }
 }

--- a/src/app/Models/Character.php
+++ b/src/app/Models/Character.php
@@ -37,7 +37,6 @@ class Character extends Model {
             'name' => $this->name,
             'vocation' => $this->vocation,
             'level' => $this->level,
-            'joining_date' => $this->joining_date,
             'type' => $this->type,
             'is_online' => $this->is_online,
             'online_at' => $this->online_at ? $this->online_at->format('Y-m-d H:i:s') : null,

--- a/src/public/js/observe.js
+++ b/src/public/js/observe.js
@@ -16,6 +16,7 @@ let positionTimeMap = new Map();
 let lastPlayed = serverDate();
 let lastOnlineCount = 0;
 let isFetching = false;
+let charactersState = new Map();
 
 function formatToHHMMSS(seconds) {
     const h = String(Math.floor(seconds / 3600)).padStart(2, '0');
@@ -255,6 +256,77 @@ function copyToClipboard(text) {
     });
 }
 
+function processCharactersData(data) {
+    charactersState.clear();
+    data.onlineCharacters.forEach(c => charactersState.set(c.name, c));
+    renderFromState();
+}
+
+function applyDiff(event) {
+    event.changes.forEach(c => charactersState.set(c.name, c));
+    event.removed.forEach(name => charactersState.delete(name));
+    renderFromState();
+}
+
+function renderFromState() {
+    const allCharacters = [...charactersState.values()];
+
+    const charactersOnlineAtMinusThanOneMinute = allCharacters.filter(character => {
+        const now = serverDate();
+        const createdAtDate = serverDate(character.online_at + " UTC");
+        const diffInSec = Math.floor((now - createdAtDate) / 1000);
+        return diffInSec < 60 && character.level > 32;
+    });
+    handleCountIncreaseAndPlay(lastOnlineCount, charactersOnlineAtMinusThanOneMinute.length);
+    lastOnlineCount = charactersOnlineAtMinusThanOneMinute.length;
+
+    clearTables();
+    createdAtMap.clear();
+    positionTimeMap.clear();
+
+    const onlineCharacters = allCharacters
+        .filter(c => c.is_online)
+        .sort((a, b) => {
+            const timeA = serverDate() - serverDate(a.online_at + " UTC");
+            const timeB = serverDate() - serverDate(b.online_at + " UTC");
+            return timeA - timeB;
+        });
+    const offlineCharacters = allCharacters
+        .filter(c => !c.is_online)
+        .sort((a, b) => {
+            return serverDate(b.offline_at + " UTC") - serverDate(a.offline_at + " UTC");
+        });
+
+    let mainIndex = 0, bombaIndex = 0, bombaoIndex = 0, makerIndex = 0;
+
+    onlineCharacters.forEach(character => {
+        if (character.type === 'main') {
+            addRow('mainCharTable', mainIndex++, character);
+        } else if (character.type === 'bomba') {
+            addRow('bombasTable', bombaIndex++, character);
+        } else if (character.type === 'bombao') {
+            addRow('bombaoTable', bombaoIndex++, character);
+        } else {
+            addRow('makersTable', makerIndex++, character);
+        }
+    });
+
+    offlineCharacters.forEach(character => {
+        const tableId = character.type === 'main' ? 'mainCharTable'
+            : character.type === 'bomba' ? 'bombasTable'
+            : character.type === 'bombao' ? 'bombaoTable'
+            : 'makersTable';
+        addRow(tableId, -1, character, true);
+    });
+
+    document.getElementById('lastUpdate').textContent =
+        `Atualizado em: ${serverDate().toLocaleTimeString()}`;
+
+    updateCreatedAtTimers();
+    updatePositionTimeTimers();
+    document.title = onlineCharacters.length + ' Characters Online';
+}
+
 async function fetchOnlineCharacters() {
     if (isFetching) return;
     isFetching = true;
@@ -263,63 +335,7 @@ async function fetchOnlineCharacters() {
         let guildName = document.getElementById('guild-name').value;
         const response = await fetch('/get-online-characters?guild_name='+guildName);
         const data = await response.json();
-
-        const charactersOnlineAtMinusThanOneMinute = data.onlineCharacters.filter(character => {
-            const now = serverDate();
-            const createdAtDate = serverDate(character.online_at+ " UTC");
-            const diffInSec = Math.floor((now - createdAtDate) / 1000);
-            if (diffInSec < 60 && character.level > 32) {
-                return character;
-            }
-        });
-        handleCountIncreaseAndPlay(lastOnlineCount, charactersOnlineAtMinusThanOneMinute.length);
-
-        lastOnlineCount = charactersOnlineAtMinusThanOneMinute.length;
-        clearTables();
-        createdAtMap.clear();
-        positionTimeMap.clear();
-
-        const onlineCharacters = data.onlineCharacters
-            .filter(c => c.is_online)
-            .sort((a, b) => {
-                const timeA = serverDate() - serverDate(a.online_at + " UTC");
-                const timeB = serverDate() - serverDate(b.online_at + " UTC");
-                return timeA - timeB;
-            });
-        const offlineCharacters = data.onlineCharacters
-            .filter(c => !c.is_online)
-            .sort((a, b) => {
-                return serverDate(b.offline_at + " UTC") - serverDate(a.offline_at + " UTC");
-            });
-
-        let mainIndex = 0, bombaIndex = 0, bombaoIndex = 0, makerIndex = 0;
-
-        onlineCharacters.forEach(character => {
-            if (character.type === 'main') {
-                addRow('mainCharTable', mainIndex++, character);
-            } else if (character.type === 'bomba') {
-                addRow('bombasTable', bombaIndex++, character);
-            } else if (character.type === 'bombao') {
-                addRow('bombaoTable', bombaoIndex++, character);
-            } else {
-                addRow('makersTable', makerIndex++, character);
-            }
-        });
-
-        offlineCharacters.forEach(character => {
-            const tableId = character.type === 'main' ? 'mainCharTable'
-                : character.type === 'bomba' ? 'bombasTable'
-                : character.type === 'bombao' ? 'bombaoTable'
-                : 'makersTable';
-            addRow(tableId, -1, character, true);
-        });
-
-        document.getElementById('lastUpdate').textContent =
-            `Atualizado em: ${serverDate().toLocaleTimeString()}`;
-
-        updateCreatedAtTimers();
-        updatePositionTimeTimers();
-        document.title = onlineCharacters.length + ' Characters Online';
+        processCharactersData(data);
     } catch (error) {
         console.error('Erro ao buscar personagens:', error);
     } finally {
@@ -368,7 +384,24 @@ function startPolling() {
 setInterval(updateCreatedAtTimers, 1000);
 setInterval(updatePositionTimeTimers, 1000);
 fetchOnlineCharacters();
-startPolling();
+
+document.addEventListener('DOMContentLoaded', function () {
+    if (window.Echo) {
+        window.Echo.channel('online-characters')
+            .subscribed(() => {
+                console.log('[Broadcast] Conectado ao canal online-characters com sucesso.');
+            })
+            .error((error) => {
+                console.error('[Broadcast] Falha ao conectar ao canal online-characters:', error);
+            })
+            .listen('OnlineCharactersUpdated', (event) => {
+                console.log('[Broadcast] Dados recebidos, atualizando a tela:', event);
+                applyDiff(event);
+            });
+    } else {
+        startPolling();
+    }
+});
 
 // --- variáveis globais ---
 let audioContext = null;

--- a/src/resources/views/layouts/default.blade.php
+++ b/src/resources/views/layouts/default.blade.php
@@ -5,6 +5,9 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>Online Characters - Dark Theme</title>
     @stack('css')
+    @if(Auth::hasUser() && Auth::user()->super_admin)
+        @vite('resources/js/app.js')
+    @endif
 </head>
 <body>
     @yield('content')

--- a/src/tests/Feature/App/Console/Commands/WorldScraperTest.php
+++ b/src/tests/Feature/App/Console/Commands/WorldScraperTest.php
@@ -11,7 +11,9 @@ use App\Models\Character;
 use App\Models\Setting;
 use App\Setting\SettingConfig;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Storage;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Tests\Support\GuildPageHtml;
@@ -30,6 +32,21 @@ class WorldScraperStub extends WorldScraper {
 }
 
 class WorldScraperTest extends TestCase {
+
+    public function tearDown(): void {
+        \Illuminate\Support\Facades\DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        parent::tearDown();
+    }
+
+    protected function setUp(): void {
+        parent::setUp();
+        Storage::fake('local');
+        Cache::flush();
+        \Illuminate\Support\Facades\DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        \Illuminate\Support\Facades\DB::table('settings')->truncate();
+        \Illuminate\Support\Facades\DB::table('characters')->truncate();
+        \Illuminate\Support\Facades\DB::statement('SET FOREIGN_KEY_CHECKS=1');
+    }
 
     private function runStub(WorldScraperStub $stub): void {
         $stub->setLaravel($this->app);
@@ -74,13 +91,13 @@ class WorldScraperTest extends TestCase {
             'is_online' => false,
         ]);
 
-        $stub = new WorldScraperStub();
+        $stub = $this->app->make(WorldScraperStub::class);
         $stub->setFakeHtml(GuildPageHtml::listOfCharacters($onlineCharacter));
         $this->runStub($stub);
 
         Event::assertDispatched(OnlineCharactersUpdated::class, function (OnlineCharactersUpdated $event) {
-            return $event->characters->count() === 1
-                && $event->characters->first()['name'] === 'TestCharacter';
+            return count($event->changes) === 1
+                && $event->changes[0]['name'] === 'TestCharacter';
         });
     }
 
@@ -98,7 +115,7 @@ class WorldScraperTest extends TestCase {
             'is_online' => false,
         ]);
 
-        $stub = new WorldScraperStub();
+        $stub = $this->app->make(WorldScraperStub::class);
         $stub->setFakeHtml(GuildPageHtml::listOfCharacters($onlineCharacter));
         $this->runStub($stub);
 
@@ -107,7 +124,7 @@ class WorldScraperTest extends TestCase {
         });
     }
 
-    public function testHandle_WhenNoOnlineCharacters_ShouldDispatchEventWithEmptyCollection(): void {
+    public function testHandle_WhenNoOnlineCharacters_ShouldDispatchEventWithRecentlyOfflineCharacters(): void {
         Event::fake();
         $guildName = GuildEnum::OUTLAW->value;
         Setting::factory()->create([
@@ -122,12 +139,13 @@ class WorldScraperTest extends TestCase {
             'online_at' => Carbon::now()->subMinutes(5),
         ]);
 
-        $stub = new WorldScraperStub();
+        $stub = $this->app->make(WorldScraperStub::class);
         $stub->setFakeHtml(GuildPageHtml::listOfCharacters($offlineCharacter));
         $this->runStub($stub);
 
         Event::assertDispatched(OnlineCharactersUpdated::class, function (OnlineCharactersUpdated $event) {
-            return $event->characters->isEmpty();
+            return count($event->changes) === 1
+                && $event->changes[0]['is_online'] === false;
         });
     }
 }

--- a/src/tests/Feature/App/Http/Controllers/HomeControllerTest.php
+++ b/src/tests/Feature/App/Http/Controllers/HomeControllerTest.php
@@ -26,6 +26,32 @@ class HomeControllerTest extends TestCase {
         $response->assertViewIs('observer');
     }
 
+    public function testIndex_WhenSuperAdmin_ShouldIncludeViteAppScript(): void {
+        Setting::factory()->create(['name' => SettingConfig::GUILD_NAME->value, 'value' => 'TestGuild']);
+        $user = User::factory()->create(['super_admin' => true]);
+
+        $response = $this->actingAs($user)->get(route('home'));
+
+        $response->assertSee('<script type="module"', false);
+    }
+
+    public function testIndex_WhenNotSuperAdmin_ShouldNotIncludeViteAppScript(): void {
+        Setting::factory()->create(['name' => SettingConfig::GUILD_NAME->value, 'value' => 'TestGuild']);
+        $user = User::factory()->create(['super_admin' => false]);
+
+        $response = $this->actingAs($user)->get(route('home'));
+
+        $response->assertDontSee('<script type="module"', false);
+    }
+
+    public function testIndex_WhenUnauthenticated_ShouldNotIncludeViteAppScript(): void {
+        Setting::factory()->create(['name' => SettingConfig::GUILD_NAME->value, 'value' => 'TestGuild']);
+
+        $response = $this->get(route('home'));
+
+        $response->assertDontSee('<script type="module"', false);
+    }
+
     public function testGetOnlineCharacters_WhenUnauthenticated_ShouldReturnOnlyOnlineCharacters(): void {
         Character::factory()->create(['is_online' => true, 'offline_at' => null]);
         Character::factory()->create(['is_online' => false, 'offline_at' => now()->subMinutes(5)]);

--- a/src/tests/Unit/App/Events/OnlineCharactersUpdatedTest.php
+++ b/src/tests/Unit/App/Events/OnlineCharactersUpdatedTest.php
@@ -4,46 +4,38 @@ namespace Tests\Unit\App\Events;
 
 use App\Events\OnlineCharactersUpdated;
 use Illuminate\Broadcasting\Channel;
-use Illuminate\Support\Collection;
 use PHPUnit\Framework\TestCase;
 
 class OnlineCharactersUpdatedTest extends TestCase {
 
-    public function testBroadcastOn_ShouldReturnPublicChannelWithGuildName(): void {
-        $event = new OnlineCharactersUpdated(collect([]), 'TestGuild');
+    public function testBroadcastOn_ShouldReturnPublicChannelWithFixedName(): void {
+        $event = new OnlineCharactersUpdated([], [], 'TestGuild');
 
         $channel = $event->broadcastOn();
 
         $this->assertInstanceOf(Channel::class, $channel);
-        $this->assertEquals('online-characters.TestGuild', $channel->name);
+        $this->assertEquals('online-characters', $channel->name);
     }
 
-    public function testBroadcastOn_ShouldIncludeGuildNameInChannelName(): void {
-        $event = new OnlineCharactersUpdated(collect([]), 'AnotherGuild');
-
-        $channel = $event->broadcastOn();
-
-        $this->assertEquals('online-characters.AnotherGuild', $channel->name);
-    }
-
-    public function testBroadcastWith_ShouldReturnOnlineCharactersKey(): void {
+    public function testBroadcastWith_ShouldReturnChangesAndRemovedKeys(): void {
         $character = ['name' => 'TestChar', 'is_online' => true, 'vocation' => 'Knight', 'level' => 100];
-        $event = new OnlineCharactersUpdated(collect([$character]), 'TestGuild');
+        $event = new OnlineCharactersUpdated([$character], [], 'TestGuild');
 
         $data = $event->broadcastWith();
 
-        $this->assertArrayHasKey('onlineCharacters', $data);
-        $this->assertCount(1, $data['onlineCharacters']);
-        $this->assertEquals('TestChar', $data['onlineCharacters'][0]['name']);
+        $this->assertArrayHasKey('changes', $data);
+        $this->assertArrayHasKey('removed', $data);
+        $this->assertCount(1, $data['changes']);
+        $this->assertEquals('TestChar', $data['changes'][0]['name']);
     }
 
-    public function testBroadcastWith_WhenEmptyCollection_ShouldReturnEmptyOnlineCharacters(): void {
-        $event = new OnlineCharactersUpdated(collect([]), 'TestGuild');
+    public function testBroadcastWith_WhenNoChanges_ShouldReturnEmptyArrays(): void {
+        $event = new OnlineCharactersUpdated([], [], 'TestGuild');
 
         $data = $event->broadcastWith();
 
-        $this->assertArrayHasKey('onlineCharacters', $data);
-        $this->assertEmpty($data['onlineCharacters']);
+        $this->assertEmpty($data['changes']);
+        $this->assertEmpty($data['removed']);
     }
 
     public function testBroadcastWith_ShouldIncludeAllCharacterFields(): void {
@@ -53,27 +45,38 @@ class OnlineCharactersUpdatedTest extends TestCase {
             'vocation' => 'Knight',
             'level' => 100,
         ];
-        $event = new OnlineCharactersUpdated(collect([$character]), 'TestGuild');
+        $event = new OnlineCharactersUpdated([$character], [], 'TestGuild');
 
         $data = $event->broadcastWith();
 
-        $charData = $data['onlineCharacters'][0];
+        $charData = $data['changes'][0];
         $this->assertEquals('TestChar', $charData['name']);
         $this->assertEquals('Knight', $charData['vocation']);
         $this->assertEquals(100, $charData['level']);
         $this->assertTrue($charData['is_online']);
     }
 
-    public function testBroadcastWith_ShouldPreserveMultipleCharacters(): void {
+    public function testBroadcastWith_ShouldPreserveMultipleChanges(): void {
         $characters = [
             ['name' => 'CharOne', 'is_online' => true],
             ['name' => 'CharTwo', 'is_online' => true],
             ['name' => 'CharThree', 'is_online' => false],
         ];
-        $event = new OnlineCharactersUpdated(collect($characters), 'TestGuild');
+        $event = new OnlineCharactersUpdated($characters, [], 'TestGuild');
 
         $data = $event->broadcastWith();
 
-        $this->assertCount(3, $data['onlineCharacters']);
+        $this->assertCount(3, $data['changes']);
+    }
+
+    public function testBroadcastWith_ShouldIncludeRemovedNames(): void {
+        $event = new OnlineCharactersUpdated([], ['CharX', 'CharY'], 'TestGuild');
+
+        $data = $event->broadcastWith();
+
+        $this->assertEmpty($data['changes']);
+        $this->assertCount(2, $data['removed']);
+        $this->assertContains('CharX', $data['removed']);
+        $this->assertContains('CharY', $data['removed']);
     }
 }


### PR DESCRIPTION
## Summary

**Backend**
- Adiciona `computeDiff` e `characterHasChanged` no `CharacterService` para calcular apenas o que mudou entre execuções
- `WorldScraper` usa `Cache` para rastrear estado anterior e dispatcha apenas `changes` e `removed`
- `OnlineCharactersUpdated` migra para `ShouldBroadcastNow` e adota contrato `changes/removed` em vez de `Collection $characters`
- Canal fixado em `online-characters` (removido sufixo de guild)
- `default.blade.php` carrega `app.js` via Vite apenas para `super_admin`
- Remove `joining_date` de `Character::toArray()`

**Frontend**
- Adiciona `charactersState` (Map) como estado local dos personagens no browser
- `processCharactersData()` inicializa o estado a partir do fetch HTTP inicial
- `applyDiff()` aplica `changes/removed` recebidos via broadcast sem refetch completo
- Substitui `startPolling()` por `window.Echo` no canal `online-characters`, com fallback para polling quando Echo não está disponível

## Test plan

- [ ] `php artisan test tests/Unit/App/Events/OnlineCharactersUpdatedTest.php`
- [ ] `php artisan test tests/Feature/App/Console/Commands/WorldScraperTest.php`
- [ ] `php artisan test tests/Feature/App/Http/Controllers/HomeControllerTest.php`
- [ ] Abrir o site como `super_admin` e verificar no DevTools → Console: `[Broadcast] Conectado ao canal online-characters com sucesso.`
- [ ] Disparar o scraper manualmente e confirmar que a tabela atualiza via WebSocket sem polling
- [ ] Abrir sem autenticação e confirmar que o polling ainda funciona

🤖 Generated with [Claude Code](https://claude.com/claude-code)