### PR TITLE
fix: adiciona trigger de push em main no workflow de CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,9 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Summary

- Adiciona trigger `push` em `main` no workflow de CI, além do `pull_request` já existente
- Garante que os testes rodam após o merge, não apenas durante o PR

## Motivação

O workflow anterior só disparava em `pull_request` targeting `main`. Após um merge, o evento gerado é `push` em `main`, então o CI nunca executava pós-merge. Além disso, ao trocar a base de um PR via `gh pr edit`, o GitHub não re-dispara o workflow automaticamente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)