### PR TITLE
feat: despacha OnlineCharactersUpdated apenas com diff ou após 1 minuto

### DIFF
--- a/src/app/Console/Commands/WorldScraper.php
+++ b/src/app/Console/Commands/WorldScraper.php
@@ -46,9 +46,12 @@ class WorldScraper extends Command {
             $cacheKey = "broadcast_state_{$searchGuild}";
             $previous = collect(Cache::get($cacheKey, []));
             $diff = $this->characterService->computeDiff($previous, $currentData);
-            Cache::put($cacheKey, $currentData->toArray(), now()->addMinute());
+            Cache::put($cacheKey, $currentData->toArray(), now()->addMinutes(2));
 
-            OnlineCharactersUpdated::dispatch($diff['changes'], $diff['removed'], $searchGuild);
+            if ($this->shouldDispatch($diff, $searchGuild)) {
+                OnlineCharactersUpdated::dispatch($diff['changes'], $diff['removed'], $searchGuild);
+                Cache::put("last_broadcast_{$searchGuild}", Carbon::now()->timestamp, now()->addMinutes(2));
+            }
             $globalExecutionEnd = microtime(true);
             $executionTime = $globalExecutionEnd - $globalExecutionBegin;
 
@@ -91,6 +94,16 @@ class WorldScraper extends Command {
         }
         $this->info('Final Date: '.Carbon::now()->toDateTimeString());
         $this->info('===================================');
+    }
+
+    private function shouldDispatch(array $diff, string $guildName): bool {
+        $hasDiff = !empty($diff['changes']) || !empty($diff['removed']);
+        if ($hasDiff) {
+            return true;
+        }
+
+        $lastBroadcast = Cache::get("last_broadcast_{$guildName}");
+        return $lastBroadcast === null || Carbon::now()->timestamp - $lastBroadcast >= 60;
     }
 
     private function createExecutionCrawler(

--- a/src/tests/Feature/App/Console/Commands/WorldScraperTest.php
+++ b/src/tests/Feature/App/Console/Commands/WorldScraperTest.php
@@ -7,6 +7,7 @@ use App\Character\GuildPageCharacter;
 use App\Character\VocationEnum;
 use App\Console\Commands\WorldScraper;
 use App\Events\OnlineCharactersUpdated;
+use App\Scrapers\GuildPage;
 use App\Models\Character;
 use App\Models\Setting;
 use App\Setting\SettingConfig;
@@ -38,6 +39,7 @@ class WorldScraperTest extends TestCase {
         parent::setUp();
         Storage::fake('local');
         Cache::flush();
+        GuildPage::reset();
         \Illuminate\Support\Facades\DB::table('settings')->truncate();
         \Illuminate\Support\Facades\DB::table('characters')->truncate();
     }
@@ -112,6 +114,61 @@ class WorldScraperTest extends TestCase {
         $stub = $this->app->make(WorldScraperStub::class);
         $stub->setFakeHtml(GuildPageHtml::listOfCharacters($onlineCharacter));
         $this->runStub($stub);
+
+        Event::assertDispatched(OnlineCharactersUpdated::class, function (OnlineCharactersUpdated $event) use ($guildName) {
+            return $event->guildName === $guildName;
+        });
+    }
+
+    public function testHandle_WhenNoDiffAndNoTimeElapsed_ShouldNotDispatchEvent(): void {
+        $guildName = GuildEnum::OUTLAW->value;
+        Setting::factory()->create([
+            'name' => SettingConfig::GUILD_NAME->value,
+            'value' => $guildName,
+        ]);
+        $onlineCharacter = $this->makeOnlineCharacter($guildName);
+        Character::factory()->create([
+            'name' => $onlineCharacter->name,
+            'guild_name' => $guildName,
+            'is_online' => true,
+        ]);
+
+        $stub = $this->app->make(WorldScraperStub::class);
+        $stub->setFakeHtml(GuildPageHtml::listOfCharacters($onlineCharacter));
+        $this->runStub($stub); // first run: populates broadcast_state cache
+
+        // ShouldBroadcastNow may throw in test environment, preventing last_broadcast from being set
+        Cache::put("last_broadcast_{$guildName}", Carbon::now()->timestamp, now()->addMinutes(2));
+        Storage::fake('local'); // reset file cache so second run queries DB fresh
+
+        Event::fake();
+        $this->runStub($stub); // second run: no diff, less than 1 minute passed
+
+        Event::assertNotDispatched(OnlineCharactersUpdated::class);
+    }
+
+    public function testHandle_WhenNoDiffButOneMinutePassed_ShouldDispatchEvent(): void {
+        $guildName = GuildEnum::OUTLAW->value;
+        Setting::factory()->create([
+            'name' => SettingConfig::GUILD_NAME->value,
+            'value' => $guildName,
+        ]);
+        $onlineCharacter = $this->makeOnlineCharacter($guildName);
+        Character::factory()->create([
+            'name' => $onlineCharacter->name,
+            'guild_name' => $guildName,
+            'is_online' => true,
+        ]);
+
+        $stub = $this->app->make(WorldScraperStub::class);
+        $stub->setFakeHtml(GuildPageHtml::listOfCharacters($onlineCharacter));
+        $this->runStub($stub); // first run: populates broadcast_state cache
+
+        Storage::fake('local'); // reset file cache so second run queries DB fresh
+        Cache::put("last_broadcast_{$guildName}", Carbon::now()->subSeconds(60)->timestamp, now()->addMinutes(2));
+
+        Event::fake();
+        $this->runStub($stub); // second run: no diff, but 1 minute passed
 
         Event::assertDispatched(OnlineCharactersUpdated::class, function (OnlineCharactersUpdated $event) use ($guildName) {
             return $event->guildName === $guildName;


### PR DESCRIPTION
## Summary

- Adiciona método `shouldDispatch` no `WorldScraper` que controla quando o evento `OnlineCharactersUpdated` é disparado
- O evento só é enviado se houver diferenças (`changes` ou `removed` não vazios) **ou** se 1 minuto tiver passado desde o último dispatch
- O timestamp do último dispatch é persistido no cache com a chave `last_broadcast_{guild}`

## Test plan

- [ ] `testHandle_WhenNoDiffAndNoTimeElapsed_ShouldNotDispatchEvent` — sem diff + menos de 1 min → não dispara
- [ ] `testHandle_WhenNoDiffButOneMinutePassed_ShouldDispatchEvent` — sem diff + 1 min passado → dispara
- [ ] Testes existentes continuam passando

🤖 Generated with [Claude Code](https://claude.com/claude-code)