### PR TITLE
feat: habilita broadcast para todos os usuários autenticados

### DIFF
--- a/src/resources/views/layouts/default.blade.php
+++ b/src/resources/views/layouts/default.blade.php
@@ -5,7 +5,7 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>Online Characters - Dark Theme</title>
     @stack('css')
-    @if(Auth::hasUser() && Auth::user()->super_admin)
+    @if(Auth::hasUser())
         @vite('resources/js/app.js')
     @endif
 </head>

--- a/src/tests/Feature/App/Http/Controllers/HomeControllerTest.php
+++ b/src/tests/Feature/App/Http/Controllers/HomeControllerTest.php
@@ -26,22 +26,13 @@ class HomeControllerTest extends TestCase {
         $response->assertViewIs('observer');
     }
 
-    public function testIndex_WhenSuperAdmin_ShouldIncludeViteAppScript(): void {
+    public function testIndex_WhenAuthenticated_ShouldIncludeViteAppScript(): void {
         Setting::factory()->create(['name' => SettingConfig::GUILD_NAME->value, 'value' => 'TestGuild']);
-        $user = User::factory()->create(['super_admin' => true]);
+        $user = User::factory()->create();
 
         $response = $this->actingAs($user)->get(route('home'));
 
         $response->assertSee('<script type="module"', false);
-    }
-
-    public function testIndex_WhenNotSuperAdmin_ShouldNotIncludeViteAppScript(): void {
-        Setting::factory()->create(['name' => SettingConfig::GUILD_NAME->value, 'value' => 'TestGuild']);
-        $user = User::factory()->create(['super_admin' => false]);
-
-        $response = $this->actingAs($user)->get(route('home'));
-
-        $response->assertDontSee('<script type="module"', false);
     }
 
     public function testIndex_WhenUnauthenticated_ShouldNotIncludeViteAppScript(): void {


### PR DESCRIPTION
## Summary
- Remove a restrição de `super_admin` no carregamento do `app.js` no layout padrão
- Agora qualquer usuário autenticado tem acesso ao broadcast via WebSocket

## Test plan
- [ ] Logar com um usuário comum (não super_admin) e verificar que o broadcast funciona normalmente
- [ ] Logar com um super_admin e verificar que o comportamento continua o mesmo

🤖 Generated with [Claude Code](https://claude.com/claude-code)