### PR TITLE
feat: redireciona usuário autenticado da home para /admin

### DIFF
--- a/src/app/Http/Middleware/AdminRedirect.php
+++ b/src/app/Http/Middleware/AdminRedirect.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class AdminRedirect
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (Auth::user() !== null && $request->routeIs('home')) {
+            return redirect()->route('admin.home');
+        }
+
+        return $next($request);
+    }
+}

--- a/src/bootstrap/app.php
+++ b/src/bootstrap/app.php
@@ -14,6 +14,7 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->append(\App\Http\Middleware\CorsMiddleware::class);
         $middleware->alias(['super_admin' => \App\Http\Middleware\SuperAdmin::class]);
+        $middleware->alias(['admin_redirect' => \App\Http\Middleware\AdminRedirect::class]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/src/bootstrap/app.php
+++ b/src/bootstrap/app.php
@@ -13,8 +13,10 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->append(\App\Http\Middleware\CorsMiddleware::class);
-        $middleware->alias(['super_admin' => \App\Http\Middleware\SuperAdmin::class]);
-        $middleware->alias(['admin_redirect' => \App\Http\Middleware\AdminRedirect::class]);
+        $middleware->alias([
+            'super_admin'    => \App\Http\Middleware\SuperAdmin::class,
+            'admin_redirect' => \App\Http\Middleware\AdminRedirect::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -4,26 +4,27 @@ use App\Http\Controllers\HomeController;
 use App\Http\Controllers\LoginController;
 use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
+Route::middleware(['admin_redirect'])->group(function () {
+    Route::get('/login', [LoginController::class, 'index'])->name('login.index');
+    Route::post('/login', [LoginController::class, 'login'])->name('login');
+    Route::get('/', [HomeController::class, 'index'])->name('home');
+    Route::get('/get-online-characters', [HomeController::class, 'getOnlineCharacters'])->name('get-online-characters');
+    Route::get('/refil', [HomeController::class, 'refil'])->name('refil');
+    Route::get('/healthcheck', [HomeController::class, 'healthcheck'])->name('healthcheck');
 
-Route::get('/login', [LoginController::class, 'index'])->name('login.index');
-Route::post('/login', [LoginController::class, 'login'])->name('login');
-Route::get('/', [HomeController::class, 'index'])->name('home');
-Route::get('/get-online-characters', [HomeController::class, 'getOnlineCharacters'])->name('get-online-characters');
-Route::get('/refil', [HomeController::class, 'refil'])->name('refil');
-Route::get('/healthcheck', [HomeController::class, 'healthcheck'])->name('healthcheck');
+    Route::middleware(['auth'])->group(function () {
+        Route::get('/admin', [HomeController::class, 'index'])->name('admin.home');
+        Route::get('/settings', [HomeController::class, 'settings'])->name('settings');
+        Route::post('/settings', [HomeController::class, 'saveSettings'])->name('settings.save');
+        Route::post('/set/{characterName}/as/{type}', [HomeController::class, 'setCharacterType'])->name('update.character.type');
+        Route::post('/set/{characterName}/as/attacker/{isAttacker}', [HomeController::class, 'setCharacterAsAttacker'])->name('update.character.attacker');
+        Route::post('/position/{characterName}', [HomeController::class, 'updateCharacterPosition'])->name('update.character.position');
+        Route::get('/online-graphics-gant', [HomeController::class, 'getCharactersOnlineGantGraphics'])->name('online-graphics-gant');
+    });
 
-Route::middleware(['auth'])->group(function () {
-    Route::get('/admin', [HomeController::class, 'index'])->name('admin.home');
-    Route::get('/settings', [HomeController::class, 'settings'])->name('settings');
-    Route::post('/settings', [HomeController::class, 'saveSettings'])->name('settings.save');
-    Route::post('/set/{characterName}/as/{type}', [HomeController::class, 'setCharacterType'])->name('update.character.type');
-    Route::post('/set/{characterName}/as/attacker/{isAttacker}', [HomeController::class, 'setCharacterAsAttacker'])->name('update.character.attacker');
-    Route::post('/position/{characterName}', [HomeController::class, 'updateCharacterPosition'])->name('update.character.position');
-    Route::get('/online-graphics-gant', [HomeController::class, 'getCharactersOnlineGantGraphics'])->name('online-graphics-gant');
-});
-
-Route::middleware(['auth', 'super_admin'])->group(function () {
-    Route::get('/users', [UserController::class, 'index'])->name('users.index');
-    Route::post('/users', [UserController::class, 'store'])->name('users.store');
-    Route::delete('/users/{user}', [UserController::class, 'destroy'])->name('users.destroy');
+    Route::middleware(['auth', 'super_admin'])->group(function () {
+        Route::get('/users', [UserController::class, 'index'])->name('users.index');
+        Route::post('/users', [UserController::class, 'store'])->name('users.store');
+        Route::delete('/users/{user}', [UserController::class, 'destroy'])->name('users.destroy');
+    });
 });

--- a/src/tests/Feature/App/Http/Controllers/HomeControllerTest.php
+++ b/src/tests/Feature/App/Http/Controllers/HomeControllerTest.php
@@ -30,7 +30,7 @@ class HomeControllerTest extends TestCase {
         Setting::factory()->create(['name' => SettingConfig::GUILD_NAME->value, 'value' => 'TestGuild']);
         $user = User::factory()->create();
 
-        $response = $this->actingAs($user)->get(route('home'));
+        $response = $this->actingAs($user)->get(route('admin.home'));
 
         $response->assertSee('<script type="module"', false);
     }

--- a/src/tests/Feature/App/Http/Middleware/AdminRedirectTest.php
+++ b/src/tests/Feature/App/Http/Middleware/AdminRedirectTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Feature\App\Http\Middleware;
+
+use App\Models\Setting;
+use App\Models\User;
+use App\Setting\SettingConfig;
+use Tests\TestCase;
+
+class AdminRedirectTest extends TestCase
+{
+    public function testHandle_WhenAuthenticatedAndAccessingHome_ShouldRedirectToAdminHome(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('home'));
+
+        $response->assertRedirect(route('admin.home'));
+    }
+
+    public function testHandle_WhenUnauthenticatedAndAccessingHome_ShouldNotRedirect(): void
+    {
+        Setting::factory()->create(['name' => SettingConfig::GUILD_NAME->value, 'value' => 'TestGuild']);
+
+        $response = $this->get(route('home'));
+
+        $response->assertStatus(200);
+    }
+
+    public function testHandle_WhenAuthenticatedAndAccessingOtherRoute_ShouldNotRedirect(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('refil'));
+
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Summary
- Corrige lógica invertida no `AdminRedirect` middleware — condição usava `!routeIs('home')` em vez de `routeIs('home')`
- Registra o middleware como alias `admin_redirect` no `bootstrap/app.php`
- Aplica o middleware em todas as rotas públicas via grupo no `web.php`
- Adiciona testes para o middleware em `AdminRedirectTest`
- Ajusta testes existentes no `HomeControllerTest` que acessavam `route('home')` com usuário autenticado para usar `route('admin.home')`

## Test plan
- [ ] Usuário autenticado acessa `/` → redireciona para `/admin`
- [ ] Usuário não autenticado acessa `/` → exibe a home normalmente
- [ ] Usuário autenticado acessa outra rota pública (ex: `/refil`) → não redireciona
- [ ] `php artisan test` passa sem falhas

🤖 Generated with [Claude Code](https://claude.com/claude-code)