### PR TITLE
feat: oculta characters offline para usuários não autenticados

### DIFF
--- a/src/public/js/observe-offline.js
+++ b/src/public/js/observe-offline.js
@@ -1,0 +1,11 @@
+function renderOfflineCharacters(allCharacters) {
+    const offlineCharacters = allCharacters
+        .filter(c => !c.is_online)
+        .sort((a, b) => {
+            return serverDate(b.offline_at + " UTC") - serverDate(a.offline_at + " UTC");
+        });
+
+    offlineCharacters.forEach(character => {
+        addRow(getTableIdForCharacterType(character.type), -1, character, true);
+    });
+}

--- a/src/public/js/observe.js
+++ b/src/public/js/observe.js
@@ -321,6 +321,17 @@ function applyDiff(event) {
     renderFromState();
 }
 
+function getTableIdForCharacterType(type) {
+    return type === 'main' ? 'mainCharTable'
+        : type === 'bomba' ? 'bombasTable'
+        : type === 'bombao' ? 'bombaoTable'
+        : 'makersTable';
+}
+
+function renderOfflineCharacters(allCharacters) {
+    // Overridden by observe-offline.js for authenticated users
+}
+
 function renderFromState() {
     const allCharacters = [...charactersState.values()];
 
@@ -344,12 +355,6 @@ function renderFromState() {
             const timeB = serverDate() - serverDate(b.online_at + " UTC");
             return timeA - timeB;
         });
-    const offlineCharacters = allCharacters
-        .filter(c => !c.is_online)
-        .sort((a, b) => {
-            return serverDate(b.offline_at + " UTC") - serverDate(a.offline_at + " UTC");
-        });
-
     let mainIndex = 0, bombaIndex = 0, bombaoIndex = 0, makerIndex = 0;
 
     onlineCharacters.forEach(character => {
@@ -364,13 +369,7 @@ function renderFromState() {
         }
     });
 
-    offlineCharacters.forEach(character => {
-        const tableId = character.type === 'main' ? 'mainCharTable'
-            : character.type === 'bomba' ? 'bombasTable'
-            : character.type === 'bombao' ? 'bombaoTable'
-            : 'makersTable';
-        addRow(tableId, -1, character, true);
-    });
+    renderOfflineCharacters(allCharacters);
 
     document.getElementById('lastUpdate').textContent =
         `Atualizado em: ${serverDate().toLocaleTimeString()}`;

--- a/src/resources/views/observer.blade.php
+++ b/src/resources/views/observer.blade.php
@@ -165,6 +165,9 @@
     <script>
         window.SERVER_TIME = "{{ now()->format('Y-m-d H:i:s') }}";
     </script>
+    @if(Auth::hasUser())
+        <script src="{{ asset('js/observe-offline.js?v=202604090000') }}"></script>
+    @endif
     <script src="{{ asset('js/observe.js?v=202604080000') }}"></script>
 
 @endsection

--- a/src/tests/Feature/App/Http/Controllers/HomeControllerTest.php
+++ b/src/tests/Feature/App/Http/Controllers/HomeControllerTest.php
@@ -38,6 +38,23 @@ class HomeControllerTest extends TestCase {
         $this->assertTrue($onlineCharacters[0]['is_online']);
     }
 
+    public function testIndex_WhenUnauthenticated_ShouldNotIncludeOfflineScript(): void {
+        Setting::factory()->create(['name' => SettingConfig::GUILD_NAME->value, 'value' => 'TestGuild']);
+
+        $response = $this->get(route('home'));
+
+        $response->assertDontSee('observe-offline.js', false);
+    }
+
+    public function testIndex_WhenAuthenticated_ShouldIncludeOfflineScript(): void {
+        Setting::factory()->create(['name' => SettingConfig::GUILD_NAME->value, 'value' => 'TestGuild']);
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('admin.home'));
+
+        $response->assertSee('observe-offline.js', false);
+    }
+
     public function testIndex_WhenAuthenticated_ShouldIncludeViteAppScript(): void {
         Setting::factory()->create(['name' => SettingConfig::GUILD_NAME->value, 'value' => 'TestGuild']);
         $user = User::factory()->create();


### PR DESCRIPTION
## Summary
- Extrai a lógica de renderização de characters offline de `observe.js` para um novo arquivo `observe-offline.js`
- Carrega `observe-offline.js` apenas quando o usuário está autenticado via `@if(Auth::hasUser())` na blade
- Extrai função utilitária `getTableIdForCharacterType()` em `observe.js` para eliminar duplicação de mapeamento type → tableId entre os dois arquivos JS

## Test plan
- [ ] Usuário não autenticado: confirmar que `observe-offline.js` não é carregado e characters offline não aparecem
- [ ] Usuário autenticado: confirmar que `observe-offline.js` é carregado e characters offline aparecem normalmente
- [ ] 2 novos testes PHPUnit adicionados e passando (`testIndex_WhenUnauthenticated_ShouldNotIncludeOfflineScript`, `testIndex_WhenAuthenticated_ShouldIncludeOfflineScript`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)