### PR TITLE
fix: corrige exibição de chars offline recentes na tela inicial

### DIFF
--- a/src/resources/views/observer.blade.php
+++ b/src/resources/views/observer.blade.php
@@ -165,9 +165,9 @@
     <script>
         window.SERVER_TIME = "{{ now()->format('Y-m-d H:i:s') }}";
     </script>
+    <script src="{{ asset('js/observe.js?v=202604080000') }}"></script>
     @if(Auth::hasUser())
         <script src="{{ asset('js/observe-offline.js?v=202604090000') }}"></script>
     @endif
-    <script src="{{ asset('js/observe.js?v=202604080000') }}"></script>
 
 @endsection

--- a/src/tests/Feature/App/Http/Controllers/HomeControllerTest.php
+++ b/src/tests/Feature/App/Http/Controllers/HomeControllerTest.php
@@ -55,6 +55,20 @@ class HomeControllerTest extends TestCase {
         $response->assertSee('observe-offline.js', false);
     }
 
+    public function testIndex_WhenAuthenticated_ShouldLoadObserveJsBeforeOfflineJs(): void {
+        Setting::factory()->create(['name' => SettingConfig::GUILD_NAME->value, 'value' => 'TestGuild']);
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('admin.home'));
+
+        $content = $response->getContent();
+        $observeJsPos = strpos($content, 'observe.js');
+        $offlineJsPos = strpos($content, 'observe-offline.js');
+        $this->assertNotFalse($observeJsPos);
+        $this->assertNotFalse($offlineJsPos);
+        $this->assertLessThan($offlineJsPos, $observeJsPos, 'observe.js deve ser carregado antes de observe-offline.js');
+    }
+
     public function testIndex_WhenAuthenticated_ShouldIncludeViteAppScript(): void {
         Setting::factory()->create(['name' => SettingConfig::GUILD_NAME->value, 'value' => 'TestGuild']);
         $user = User::factory()->create();


### PR DESCRIPTION
## Summary
- `observe-offline.js` era carregado antes de `observe.js`, fazendo com que `observe.js` sobrescrevesse `renderOfflineCharacters` com um placeholder vazio
- Invertida a ordem dos scripts: `observe.js` carrega primeiro (define o placeholder) e `observe-offline.js` carrega depois (sobrescreve com a implementação real)
- Adicionado teste que valida a ordem de carregamento dos scripts

## Test plan
- [ ] Verificar que personagens offline há menos de 15 minutos aparecem na tela ao carregar para usuários autenticados
- [ ] Verificar que personagens offline continuam ocultos para usuários não autenticados
- [ ] `php artisan test --filter HomeControllerTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)